### PR TITLE
Update GitHub rate limit docs link

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -105,7 +105,7 @@
       </header>
       <section class="modal-card-body">
         <p><em>Useful Forks</em> uses the GitHub API to retrieve repository metadata. You may see this dialog because you have hit the
-          <a href="https://developer.github.com/v3/#rate-limiting" target="_blank" rel="noopener noreferrer">
+          <a href="https://docs.github.com/rest/rate-limit" target="_blank" rel="noopener noreferrer">
             GitHub API rate limit</a>.
         </p><br/>
         <p>To raise that limit (it increases it by almost 5000 calls per hour), you should provide a personal Access Token.</p><br/>


### PR DESCRIPTION
The current link doesn't lead to rate limit page.