### PR TITLE
Use multiplication sign where applicable (#49)

### DIFF
--- a/plugin/useful-forks.js
+++ b/plugin/useful-forks.js
@@ -168,8 +168,8 @@ function build_fork_element_html(table_body, combined_name, num_stars, num_forks
   table_body.append(
       NEW_ROW.append(
           $('<td>').html(svg_literal_fork + ` <a href="https://github.com/${combined_name}" target="_blank" rel="noopener noreferrer">${combined_name}</a>`),
-          $('<td>').html(UF_TABLE_SEPARATOR + svg_literal_star + ' x ' + num_stars).attr("value", num_stars),
-          $('<td>').html(UF_TABLE_SEPARATOR + svg_literal_fork + ' x ' + num_forks).attr("value", num_forks)
+          $('<td>').html(UF_TABLE_SEPARATOR + svg_literal_star + ' × ' + num_stars).attr("value", num_stars),
+          $('<td>').html(UF_TABLE_SEPARATOR + svg_literal_fork + ' × ' + num_forks).attr("value", num_forks)
       )
   );
   return NEW_ROW;

--- a/website/src/queries-init.js
+++ b/website/src/queries-init.js
@@ -45,13 +45,13 @@ function getRepoCol(full_name, isInitialRepo) {
                          onclick="ga_queryResultClick('${full_name}', ${isInitialRepo});">${full_name}</a>`;
 }
 function getStarCol(num_stars) {
-  return SVG_STAR + ' x ' + num_stars;
+  return SVG_STAR + ' × ' + num_stars;
 }
 function getForkCol(num_forks) {
-  return SVG_FORK + ' x ' + num_forks;
+  return SVG_FORK + ' × ' + num_forks;
 }
 function getWatchCol(num_watchers) {
-  return SVG_EYE + ' x ' + num_watchers;
+  return SVG_EYE + ' × ' + num_watchers;
 }
 function getDateCol(date) {
   return SVG_DATE + ' ' + date;


### PR DESCRIPTION
On results pages where the list of forks shows how many stars, forks, and watchers that each has, there is a lowercase letter x (`x`) where a multiplication sign (`×`) would serve better. This pull request will fix #49.