### PR TITLE
Add GitHub-style filter for columns (fix #37)

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -215,7 +215,7 @@
           </p>
         </div>
         <div class="control" id="filterContainer" hidden>
-          <input class="input is-dark" type="text" id="filter" name="filter"
+          <input class="input" type="text" id="filter" name="filter"
                  title='GitHub style syntax, with some aliases like "a" for "ahead", "d" for the date, etc. (see https://docs.github.com/en/search-github/getting-started-with-searching-on-github/about-searching-on-github)'
                  placeholder="Type your filter here. eg: ahead:>=1 behind:<5" />
         </div>

--- a/website/index.html
+++ b/website/index.html
@@ -230,11 +230,11 @@
               Find useful forks
             </button>
           </p>
-          </div>
-          <div class="control" id="filterContainer" hidden>
-            <input class="input is-dark" type="text" id="filter" name="filter"
-              placeholder="Type your filter here. eg: ahead:>=1 behind:<5" />
-          </div>
+        </div>
+        <div class="control" id="filterContainer" hidden>
+          <input class="input is-dark" type="text" id="filter" name="filter"
+            placeholder="Type your filter here. eg: ahead:>=1 behind:<5" />
+        </div>
       </div>
     </div>
     <div class="container" id="useful_forks_inject">

--- a/website/index.html
+++ b/website/index.html
@@ -230,11 +230,10 @@
               Find useful forks
             </button>
           </p>
-          <div class="control is-expanded"></div>
+          </div>
           <div class="control">
             <input class="input is-dark" type="text" id="filter" name="filter" placeholder="eg: ahead:>=1 behind:<5" />
           </div>
-        </div>
       </div>
     </div>
     <div class="container" id="useful_forks_inject">

--- a/website/index.html
+++ b/website/index.html
@@ -195,7 +195,7 @@
                   Display
                 </label>
               </div>
-              <p class="help mb-2"><strong>Default is checked.</strong> Determines whether to display or not the "<span class="is-family-monospace">Export table as CSV</span>" button when a scan ends.</p>
+              <p class="help mb-2"><strong>Default is checked.</strong> Determines whether to display or not the "<span class="is-family-monospace">Export table below as CSV</span>" button when a scan ends.</p>
             </div>
           </div>
         </div>

--- a/website/index.html
+++ b/website/index.html
@@ -231,8 +231,9 @@
             </button>
           </p>
           </div>
-          <div class="control">
-            <input class="input is-dark" type="text" id="filter" name="filter" placeholder="Type your filter here. eg: ahead:>=1 behind:<5" />
+          <div class="control" id="filterContainer" hidden>
+            <input class="input is-dark" type="text" id="filter" name="filter"
+              placeholder="Type your filter here. eg: ahead:>=1 behind:<5" />
           </div>
       </div>
     </div>

--- a/website/index.html
+++ b/website/index.html
@@ -232,7 +232,7 @@
           </p>
           </div>
           <div class="control">
-            <input class="input is-dark" type="text" id="filter" name="filter" placeholder="eg: ahead:>=1 behind:<5" />
+            <input class="input is-dark" type="text" id="filter" name="filter" placeholder="Type your filter here. eg: ahead:>=1 behind:<5" />
           </div>
       </div>
     </div>

--- a/website/index.html
+++ b/website/index.html
@@ -216,8 +216,8 @@
         </div>
         <div class="control" id="filterContainer" hidden>
           <input class="input" type="text" id="filter" name="filter"
-                 title='GitHub style syntax, with some aliases like "a" for "ahead", "d" for the date, etc. (see https://docs.github.com/en/search-github/getting-started-with-searching-on-github/about-searching-on-github)'
-                 placeholder="Type your filter here. eg: ahead:>=1 behind:<5" />
+                 title='There are aliases too (e.g. "a" for "ahead", "d" for the date, etc.). There is an implicit AND boolean operator in between each filter.'
+                 placeholder="Type your filter here. eg: ahead>=1 behind<5" />
         </div>
       </div>
     </div>

--- a/website/index.html
+++ b/website/index.html
@@ -139,23 +139,6 @@
       <section class="modal-card-body">
         <p>Settings will be saved on your local browser and will apply to your future queries.</p><br/>
 
-        <!-- Amount of commit diffs for the automatic filtering. -->
-        <div class="field is-horizontal">
-          <div class="field-label is-normal">
-            <label class="label">Ahead filter:</label>
-          </div>
-          <div class="field-body">
-            <div class="field">
-              <div class="control">
-                <input id="uf_settings_filter" class="input is-small is-fullwidth has-tooltip-arrow"
-                       type="number" value="0" min="1"
-                       placeholder="Default is 0" required>
-              </div>
-              <p class="help mb-2"><strong>Default is 0.</strong> If the amount of 'ahead' commits is less than or equal to this value, the fork is automatically removed from the list.</p>
-            </div>
-          </div>
-        </div>
-
         <!-- Relationship used for the commit diff count. -->
         <div class="field is-horizontal">
           <div class="field-label is-normal">

--- a/website/index.html
+++ b/website/index.html
@@ -230,6 +230,10 @@
               Find useful forks
             </button>
           </p>
+          <div class="control is-expanded"></div>
+          <div class="control">
+            <input class="input is-dark" type="text" id="filter" name="filter" placeholder="eg: ahead:>=1 behind:<5" />
+          </div>
         </div>
       </div>
     </div>

--- a/website/index.html
+++ b/website/index.html
@@ -233,7 +233,8 @@
         </div>
         <div class="control" id="filterContainer" hidden>
           <input class="input is-dark" type="text" id="filter" name="filter"
-            placeholder="Type your filter here. eg: ahead:>=1 behind:<5" />
+                 title='GitHub style syntax, with some aliases like "a" for "ahead", "d" for the date, etc. (see https://docs.github.com/en/search-github/getting-started-with-searching-on-github/about-searching-on-github)'
+                 placeholder="Type your filter here. eg: ahead:>=1 behind:<5" />
         </div>
       </div>
     </div>

--- a/website/src/csv-export.js
+++ b/website/src/csv-export.js
@@ -11,18 +11,14 @@ function displayCsvExportBtn() {
   if (!UF_SETTINGS_CSV_DISPLAY) {
     return;
   }
-  if (!tableIsEmpty()) {
-    JQ_ID_HEADER.append(EXPORT_DIV);
-    setClickEvent();
-  }
+  JQ_ID_HEADER.append(EXPORT_DIV);
+  setClickEvent();
 }
 function hideExportCsvBtn() {
   if (!UF_SETTINGS_CSV_DISPLAY) {
     return;
   }
-  if (!tableIsEmpty()) {
-    getJqId_$(EXPORT_DIV_ID).remove();
-  }
+  getJqId_$(EXPORT_DIV_ID).remove();
 }
 function setClickEvent() {
   EXPORT_BTN.on('click', function (event) {

--- a/website/src/csv-export.js
+++ b/website/src/csv-export.js
@@ -3,7 +3,7 @@ const EXPORT_DIV_BTN = "uf_csv_export_btn";
 const EXPORT_BTN = $('<a>', {id: EXPORT_DIV_BTN, class: "button is-dark is-outlined is-small"})
                    .attr("href", "#")
                    .prepend($('<img>', {src: "assets/csv_dl.svg", class: "mr-2", alt: "csv", width: "26", height: "26"}))
-                   .append("Export table as CSV");
+                   .append("Export table below as CSV");
 const EXPORT_DIV = $('<div>', {id: EXPORT_DIV_ID, class: "mt-2"}).append(EXPORT_BTN);
 
 

--- a/website/src/queries-init.js
+++ b/website/src/queries-init.js
@@ -27,6 +27,11 @@ const UF_PRESERVED_MSGS = [
     UF_MSG_API_RATE
 ];
 
+// messages about the current state of the scan but not about the results
+const UF_MSGS_SCAN_STATE = [
+  UF_MSG_SCANNING,
+  UF_MSG_SLOWER
+];
 
 const EXAMPLE_LINK_1 = `<a href="${buildAutoQueryURL('payne911/PieMenu')}"
                            onclick="ga_shortExampleLink();">payne911/PieMenu</a>`;
@@ -119,6 +124,14 @@ function clearNonErrorMsg() {
   if (!UF_PRESERVED_MSGS.includes(msg))
     clearMsg();
 }
+
+function clearNonScanStateMsg() {
+  const msg = JQ_ID_MSG.html();
+  if (!UF_MSGS_SCAN_STATE.includes(msg) && !UF_PRESERVED_MSGS.includes(msg)) {
+    clearMsg();
+  }
+}
+
 function setHeader(msg) {
   JQ_ID_HEADER.html(msg);
 }

--- a/website/src/queries-init.js
+++ b/website/src/queries-init.js
@@ -102,6 +102,11 @@ function setMsg(msg) {
     .css("border-color", "rgba(0,0,0,0.25)")
     .css("border-style", "solid");
 }
+
+function isMsgEmpty() {
+  return JQ_ID_MSG.html() === "";
+}
+
 function clearMsg() {
   JQ_ID_MSG
     .empty()

--- a/website/src/queries-init.js
+++ b/website/src/queries-init.js
@@ -22,7 +22,6 @@ const UF_MSG_API_RATE     = "<b>GitHub API rate-limits exceeded.</b> Consider pr
 // list of messages which should not be cleared when the request ends
 const UF_PRESERVED_MSGS = [
     UF_MSG_NO_FORKS,
-    UF_MSG_EMPTY_FILTER,
     UF_MSG_ERROR,
     UF_MSG_API_RATE
 ];

--- a/website/src/queries-init.js
+++ b/website/src/queries-init.js
@@ -2,6 +2,7 @@ const SELF_URL = "https://useful-forks.github.io/";
 
 const JQ_REPO_FIELD  = $('#repo');
 const JQ_FILTER_FIELD = $('#filter');
+const JQ_FILTER_CONTAINER = $('#filterContainer');
 const JQ_SEARCH_BTN  = $('#searchBtn');
 const JQ_TOTAL_CALLS = $('#totalApiCalls');
 
@@ -154,6 +155,14 @@ function getQueryOrDefault(defaultVal) {
     JQ_REPO_FIELD.val(defaultVal);
   }
   return JQ_REPO_FIELD.val();
+}
+
+function hideFilterContainer() {
+  JQ_FILTER_CONTAINER.hide();
+}
+
+function showFilterContainer() {
+  JQ_FILTER_CONTAINER.show();
 }
 
 function getFilterOrDefault(defaultVal) {

--- a/website/src/queries-init.js
+++ b/website/src/queries-init.js
@@ -113,7 +113,6 @@ function clearMsg() {
     .empty()
     .removeClass("box")
     .css("border-style", "");
-  removeProgressBar();
 }
 function clearNonErrorMsg() {
   const msg = JQ_ID_MSG.html();

--- a/website/src/queries-init.js
+++ b/website/src/queries-init.js
@@ -1,6 +1,7 @@
 const SELF_URL = "https://useful-forks.github.io/";
 
 const JQ_REPO_FIELD  = $('#repo');
+const JQ_FILTER_FIELD = $('#filter');
 const JQ_SEARCH_BTN  = $('#searchBtn');
 const JQ_TOTAL_CALLS = $('#totalApiCalls');
 
@@ -149,6 +150,13 @@ function getQueryOrDefault(defaultVal) {
     JQ_REPO_FIELD.val(defaultVal);
   }
   return JQ_REPO_FIELD.val();
+}
+
+function getFilterOrDefault(defaultVal) {
+  if (!JQ_FILTER_FIELD.val()) {
+    JQ_FILTER_FIELD.val(defaultVal);
+  }
+  return JQ_FILTER_FIELD.val();
 }
 
 function setApiCallsLabel(total) {

--- a/website/src/queries-logic.js
+++ b/website/src/queries-logic.js
@@ -306,7 +306,8 @@ function update_table(data) {
 function updateFilterFunction() {
   const filter = getFilterOrDefault();
   if (filter === '') {
-    return; // no filter
+    IS_USEFUL_FORK = () => true; // no filter
+    return;
   }
 
   const mapTable = {
@@ -551,7 +552,4 @@ if (JQ_REPO_FIELD.val()) {
   JQ_SEARCH_BTN.click();
 }
 
-JQ_FILTER_FIELD.keyup(event => {
-  // User updated the filter field, so we need to re-filter the table. 
-  update_filter();
-});
+JQ_FILTER_FIELD.on('input', update_filter);

--- a/website/src/queries-logic.js
+++ b/website/src/queries-logic.js
@@ -200,7 +200,7 @@ function update_table_data(responseData, user, repo, parentDefaultBranch) {
     return;
   }
 
-  if (!RATE_LIMIT_EXCEEDED) {// because some times gets called after some other msgs are displayed
+  if (!RATE_LIMIT_EXCEEDED) { // because some times gets called after some other msgs are displayed
     clearNonErrorMsg();
     removeProgressBar();
   }

--- a/website/src/queries-logic.js
+++ b/website/src/queries-logic.js
@@ -346,25 +346,26 @@ function updateFilterFunction() {
   
   IS_USEFUL_FORK = (datum) => {
     for (const [attribute, { operator, value }] of Object.entries(conditionObj)) {
+      const attrValue = datum[attribute];
       switch (operator) {
         case '>':
-          if (datum[attribute] <= value)
+          if (attrValue <= value)
             return false;
           break;
         case '>=':
-          if (datum[attribute] < value)
+          if (attrValue < value)
             return false;
           break;
         case '<':
-          if (datum[attribute] >= value)
+          if (attrValue >= value)
             return false;
           break;
         case '<=':
-          if (datum[attribute] > value)
+          if (attrValue > value)
             return false;
           break;
         case '=':
-          if (datum[attribute] != value)
+          if (attrValue != value)
             return false;
           break;
       }

--- a/website/src/queries-logic.js
+++ b/website/src/queries-logic.js
@@ -279,7 +279,12 @@ function getFilterFunction() {
   const mapTable = {
     'ahead': 'ahead_by',
     'behind': 'behind_by',
-    'pushed': 'pushed_at'
+    'pushed': 'pushed_at',
+    'a': 'ahead_by',
+    'b': 'behind_by',
+    'p': 'pushed_at',
+    's': 'stars',
+    'f': 'forks',
   };
 
   // parse filter string into condition object

--- a/website/src/queries-logic.js
+++ b/website/src/queries-logic.js
@@ -5,7 +5,8 @@ const { throttling } = require("@octokit/plugin-throttling");
 /* Filtering constants. */
 const attributeRgx = '([a-z]+)';
 const operatorRgx = '(<=|>=|[<=>])';
-const valueRgx = '([0-9]{4}-[0-9]{2}-[0-9]{2}|[0-9]+)';
+const dateRgx = '[0-9]{4}-[0-9]{2}-[0-9]{2}';
+const valueRgx = `(${dateRgx}|[0-9]+)`;
 const regex = new RegExp(attributeRgx + operatorRgx + valueRgx);
 const mapTable = {
   'ahead': 'ahead_by',

--- a/website/src/queries-logic.js
+++ b/website/src/queries-logic.js
@@ -6,7 +6,6 @@ let TABLE_DATA = [];
 let REPO_DATE;
 let TOTAL_FORKS;
 let RATE_LIMIT_EXCEEDED;
-let AHEAD_COMMITS_FILTER;
 let TOTAL_API_CALLS_COUNTER;
 let ONGOING_REQUESTS_COUNTER = 0;
 let IS_USEFUL_FORK; // function that determines if a fork is useful or not
@@ -26,7 +25,6 @@ function clear_old_data() {
   RATE_LIMIT_EXCEEDED = false;
   TOTAL_API_CALLS_COUNTER = 0;
   ONGOING_REQUESTS_COUNTER = 0;
-  AHEAD_COMMITS_FILTER = UF_SETTINGS_AHEAD_FILTER;
   shouldTriggerQueryOnTokenSave = false;
 }
 
@@ -234,7 +232,7 @@ function update_table_data(responseData, user, repo, parentDefaultBranch) {
       head: `${extract_username_from_fork(currFork.full_name)}:${currFork.default_branch}`
     });
     const onSuccess = (responseHeaders, responseData) => {
-      if (responseData.total_commits > AHEAD_COMMITS_FILTER) {
+      if (responseData.total_commits > 0) {
         datum['ahead_by'] = responseData.ahead_by;
         datum['ahead_url'] = responseData.html_url;
         datum['behind_by'] = responseData.behind_by;

--- a/website/src/queries-logic.js
+++ b/website/src/queries-logic.js
@@ -5,7 +5,7 @@ const { throttling } = require("@octokit/plugin-throttling");
 /* Filtering constants. */
 const attributeRgx = '([a-z]+)';
 const operatorRgx = '(<=|>=|[<=>])';
-const dateRgx = '[0-9]{4}-[0-9]{2}-[0-9]{2}';
+const dateRgx = '[0-9]{4}(?:(?<!-|-[0-9])-[0-9]{0,2}){0,2}';
 const valueRgx = `(${dateRgx}|[0-9]+)`;
 const regex = new RegExp(attributeRgx + operatorRgx + valueRgx);
 const mapTable = {

--- a/website/src/queries-logic.js
+++ b/website/src/queries-logic.js
@@ -137,11 +137,17 @@ function allRequestsAreDone() {
 function decrementCounters() {
   ONGOING_REQUESTS_COUNTER--;
   if (allRequestsAreDone()) {
-    if (tableIsEmpty(getTableBody())) {
-      setMsg(UF_MSG_EMPTY_FILTER);
-    }
-    clearNonErrorMsg();
+    manageMsgs();
     enableQueryFields();
+  }
+}
+
+function manageMsgs() {
+  clearNonErrorMsg();
+  if (tableIsEmpty(getTableBody())) {
+    setMsg(UF_MSG_EMPTY_FILTER);
+    hideExportCsvBtn();
+  } else {
     displayCsvExportBtn();
   }
 }
@@ -222,14 +228,14 @@ function update_table_data(responseData, user, repo, parentDefaultBranch, is_use
 }
 
 function update_filter() {
-  clearNonErrorMsg();
-  
   let is_useful_fork = getFilterFunction()
   if (typeof is_useful_fork === 'function') {
     update_table(TABLE_DATA.filter(is_useful_fork));
   } else {
     update_table(TABLE_DATA);
   }
+
+  manageMsgs();
 }
 
 /**

--- a/website/src/queries-logic.js
+++ b/website/src/queries-logic.js
@@ -282,7 +282,13 @@ function getFilterFunction() {
   let conditionObj = {};
   for (const condition of conditionStrList) {
     let [attribute, requirement] = condition.split(':');
+    if (!attribute || !requirement) {
+      return; // invalid filter
+    }
     const [_, operator, value] = requirement.split(/([<>=]+)/);
+    if (!operator || !value) {
+      return; // invalid filter
+    }
     if (attribute in mapTable) {
       attribute = mapTable[attribute];
     }

--- a/website/src/queries-logic.js
+++ b/website/src/queries-logic.js
@@ -14,6 +14,7 @@ let ONGOING_REQUESTS_COUNTER = 0;
 function clear_old_data() {
   clearHeader();
   clearMsg();
+  removeProgressBar();
   TABLE_DATA = []; // clear the table data
   clearTable(); // clear the table DOM
   setApiCallsLabel(0);
@@ -138,6 +139,7 @@ function decrementCounters() {
   ONGOING_REQUESTS_COUNTER--;
   if (allRequestsAreDone()) {
     manageMsgs();
+    removeProgressBar();
     enableQueryFields();
   }
 }
@@ -195,8 +197,10 @@ function update_table_data(responseData, user, repo, parentDefaultBranch, is_use
     return;
   }
 
-  if (!RATE_LIMIT_EXCEEDED) // because some times gets called after some other msgs are displayed
+  if (!RATE_LIMIT_EXCEEDED) {// because some times gets called after some other msgs are displayed
     clearNonErrorMsg();
+    removeProgressBar();
+  }
 
   for (const currFork of responseData) {
     if (RATE_LIMIT_EXCEEDED) // we can skip everything below because they are only requests

--- a/website/src/queries-logic.js
+++ b/website/src/queries-logic.js
@@ -143,9 +143,11 @@ function decrementCounters() {
 }
 
 function manageMsgs() {
-  clearNonErrorMsg();
+  clearNonErrorMsg()
   if (tableIsEmpty(getTableBody())) {
-    setMsg(UF_MSG_EMPTY_FILTER);
+    if (isMsgEmpty()) {
+      setMsg(UF_MSG_EMPTY_FILTER);
+    }
     hideExportCsvBtn();
   } else {
     displayCsvExportBtn();

--- a/website/src/queries-logic.js
+++ b/website/src/queries-logic.js
@@ -1,6 +1,25 @@
 const { Octokit } = require("@octokit/rest");
 const { throttling } = require("@octokit/plugin-throttling");
 
+
+/* Filtering constants. */
+const attributeRgx = '([a-z]+)';
+const operatorRgx = '(<=|>=|[<=>])';
+const valueRgx = '([0-9]{4}-[0-9]{2}-[0-9]{2}|[0-9]+)';
+const regex = new RegExp(attributeRgx + operatorRgx + valueRgx);
+const mapTable = {
+  'ahead': 'ahead_by',
+  'behind': 'behind_by',
+  'pushed': 'pushed_at',
+  'date': 'pushed_at',
+  'd': 'pushed_at',
+  'a': 'ahead_by',
+  'b': 'behind_by',
+  'p': 'pushed_at',
+  's': 'stars',
+  'f': 'forks',
+};
+
 /* Variables that should be cleared for every new query (defaults are set in "clear_old_data"). */
 let TABLE_DATA = [];
 let REPO_DATE;
@@ -310,28 +329,10 @@ function updateFilterFunction() {
     return;
   }
 
-  const mapTable = {
-    'ahead': 'ahead_by',
-    'behind': 'behind_by',
-    'pushed': 'pushed_at',
-    'date': 'pushed_at',
-    'd': 'pushed_at',
-    'a': 'ahead_by',
-    'b': 'behind_by',
-    'p': 'pushed_at',
-    's': 'stars',
-    'f': 'forks',
-  };
-
   // parse filter string into condition object
   const conditionStrList = filter.split(' ');
   let conditionObj = {};
   for (const condition of conditionStrList) {
-    const attributeRgx = '([a-z]+)';
-    const operatorRgx = '(<=|>=|[<=>])';
-    const valueRgx = '([0-9]{4}-[0-9]{2}-[0-9]{2}|[0-9]+)';
-    const regex = new RegExp(attributeRgx + operatorRgx + valueRgx);
-
     const matchResult = condition.match(regex);
     let [attribute, operator, value] = matchResult ? matchResult.slice(1) : [];
     if (!attribute || !operator || !value) {

--- a/website/src/queries-logic.js
+++ b/website/src/queries-logic.js
@@ -194,6 +194,14 @@ function update_table_trying_use_filter() {
   }
 }
 
+function is_duplicate_repo(name) {
+  for (const fork of TABLE_DATA) {
+    if (fork['name'] === name)
+      return true;
+  }
+  return false;
+}
+
 /** Updates table data, then calls function to update the table. */
 function update_table_data(responseData, user, repo, parentDefaultBranch) {
   if (isEmpty(responseData)) {
@@ -208,6 +216,9 @@ function update_table_data(responseData, user, repo, parentDefaultBranch) {
   for (const currFork of responseData) {
     if (RATE_LIMIT_EXCEEDED) // we can skip everything below because they are only requests
       continue;
+
+    if (is_duplicate_repo(currFork.full_name))
+      continue; // abort because repo is already listed
 
     let datum = {
       'name': currFork.full_name,

--- a/website/src/queries-logic.js
+++ b/website/src/queries-logic.js
@@ -143,7 +143,7 @@ function decrementCounters() {
 }
 
 function manageMsgs() {
-  clearNonErrorMsg()
+  clearNonErrorMsg();
   if (tableIsEmpty(getTableBody())) {
     if (isMsgEmpty()) {
       setMsg(UF_MSG_EMPTY_FILTER);
@@ -174,6 +174,19 @@ function send(requestPromise, successFn, failureFn) {
       () => failureFn())
   .finally(
       () => decrementCounters());
+}
+
+/** Add bold to the date text if the date is earlier than the queried repo. */
+function compareDates(date, html) {
+  return REPO_DATE <= new Date(date) ? `<strong>${html}</strong>` : html;
+}
+
+function update_table_trying_use_filter(is_useful_fork) {
+  if (typeof is_useful_fork === 'function') {
+    update_table(TABLE_DATA.filter(is_useful_fork));
+  } else {
+    update_table(TABLE_DATA);
+  }
 }
 
 /** Updates table data, then calls function to update the table. */
@@ -213,11 +226,7 @@ function update_table_data(responseData, user, repo, parentDefaultBranch, is_use
         TABLE_DATA.push(datum);
         if (TABLE_DATA.length > 1) showFilterContainer();
         
-        if (typeof is_useful_fork === 'function') {
-          update_table(TABLE_DATA.filter(is_useful_fork));
-        } else {
-          update_table(TABLE_DATA);
-        }
+        update_table_trying_use_filter(is_useful_fork);
       }
     };
     const onFailure = () => { }; // do nothing
@@ -232,11 +241,7 @@ function update_table_data(responseData, user, repo, parentDefaultBranch, is_use
 
 function update_filter() {
   let is_useful_fork = getFilterFunction()
-  if (typeof is_useful_fork === 'function') {
-    update_table(TABLE_DATA.filter(is_useful_fork));
-  } else {
-    update_table(TABLE_DATA);
-  }
+  update_table_trying_use_filter(is_useful_fork);
 
   manageMsgs();
 }
@@ -336,11 +341,6 @@ function getFilterFunction() {
     return true;
   }
   return is_useful_fork;
-}
-
-/** Add bold to the date text if the date is earlier than the queried repo. */
-function compareDates(date, html) {
-  return REPO_DATE <= new Date(date) ? `<strong>${html}</strong>` : html;
 }
 
 /** Paginated (index starts at 1) recursive forks scan. */

--- a/website/src/queries-logic.js
+++ b/website/src/queries-logic.js
@@ -195,9 +195,8 @@ function update_table_data(responseData, user, repo, parentDefaultBranch, is_use
     return;
   }
 
-  if (!RATE_LIMIT_EXCEEDED) {// because some times gets called after some other msgs are displayed
+  if (!RATE_LIMIT_EXCEEDED) // because some times gets called after some other msgs are displayed
     clearNonErrorMsg();
-  }
 
   for (const currFork of responseData) {
     if (RATE_LIMIT_EXCEEDED) // we can skip everything below because they are only requests

--- a/website/src/queries-logic.js
+++ b/website/src/queries-logic.js
@@ -287,6 +287,8 @@ function getFilterFunction() {
     'ahead': 'ahead_by',
     'behind': 'behind_by',
     'pushed': 'pushed_at',
+    'date': 'pushed_at',
+    'd': 'pushed_at',
     'a': 'ahead_by',
     'b': 'behind_by',
     'p': 'pushed_at',

--- a/website/src/queries-logic.js
+++ b/website/src/queries-logic.js
@@ -138,14 +138,15 @@ function allRequestsAreDone() {
 function decrementCounters() {
   ONGOING_REQUESTS_COUNTER--;
   if (allRequestsAreDone()) {
-    manageMsgs();
+    clearNonErrorMsg();
     removeProgressBar();
+    updateBasedOnTable();
     enableQueryFields();
   }
 }
 
-function manageMsgs() {
-  clearNonErrorMsg();
+function updateBasedOnTable() {
+  clearNonScanStateMsg();
   if (tableIsEmpty(getTableBody())) {
     if (isMsgEmpty()) {
       setMsg(UF_MSG_EMPTY_FILTER);
@@ -246,7 +247,7 @@ function update_filter() {
   let is_useful_fork = getFilterFunction()
   update_table_trying_use_filter(is_useful_fork);
 
-  manageMsgs();
+  updateBasedOnTable();
 }
 
 /**

--- a/website/src/queries-logic.js
+++ b/website/src/queries-logic.js
@@ -254,7 +254,17 @@ function update_table_data(responseData, user, repo, parentDefaultBranch) {
   }
 }
 
+function update_filter_appearance() {
+  const filter = getFilterOrDefault();
+  if (filter === '') {
+    JQ_FILTER_FIELD.removeClass('is-dark');
+  } else {
+    JQ_FILTER_FIELD.addClass('is-dark');
+  }
+}
+
 function update_filter() {
+  update_filter_appearance();
   updateFilterFunction();
   update_table_trying_use_filter();
 

--- a/website/src/queries-logic.js
+++ b/website/src/queries-logic.js
@@ -505,7 +505,6 @@ if (JQ_REPO_FIELD.val()) {
 }
 
 JQ_FILTER_FIELD.keyup(event => {
-  if (event.keyCode === 13) { // 'ENTER'
-    update_filter();
-  }
+  // User updated the filter field, so we need to re-filter the table. 
+  update_filter();
 });

--- a/website/src/queries-logic.js
+++ b/website/src/queries-logic.js
@@ -211,7 +211,8 @@ function update_table_data(responseData, user, repo, parentDefaultBranch, is_use
         datum['behind_url'] = getBehindUrl(responseData.html_url);
         datum['pushed_at'] = getOnlyDate(currFork.pushed_at);
         TABLE_DATA.push(datum);
-
+        if (TABLE_DATA.length > 1) showFilterContainer();
+        
         if (typeof is_useful_fork === 'function') {
           update_table(TABLE_DATA.filter(is_useful_fork));
         } else {
@@ -455,6 +456,7 @@ function initiate_search() {
   setUpOctokitWithLatestToken();
 
   setQueryFieldsAsLoading();
+  hideFilterContainer();
   setMsg(UF_MSG_SCANNING);
 
   const user = queryValues[len - 2];

--- a/website/src/queries-logic.js
+++ b/website/src/queries-logic.js
@@ -552,4 +552,5 @@ if (JQ_REPO_FIELD.val()) {
   JQ_SEARCH_BTN.click();
 }
 
+/* User updated the filters, so we refresh the table. */
 JQ_FILTER_FIELD.on('input', update_filter);

--- a/website/src/queries-logic.js
+++ b/website/src/queries-logic.js
@@ -265,6 +265,11 @@ function update_table(data) {
   sortTable();
 }
 
+/**
+ * 1. Empty filter means no filter.
+ * 2. Filter string is a list of conditions separated by spaces.
+ * 3. If a condition is invalid, it is ignored, and the rest of the conditions are applied.
+ */
 function getFilterFunction() {
   const filter = getFilterOrDefault();
   if (filter === '') {
@@ -283,11 +288,11 @@ function getFilterFunction() {
   for (const condition of conditionStrList) {
     let [attribute, requirement] = condition.split(':');
     if (!attribute || !requirement) {
-      return; // invalid filter
+      continue; // invalid condition
     }
     const [_, operator, value] = requirement.split(/([<>=]+)/);
     if (!operator || !value) {
-      return; // invalid filter
+      continue; // invalid condition
     }
     if (attribute in mapTable) {
       attribute = mapTable[attribute];

--- a/website/src/queries-logic.js
+++ b/website/src/queries-logic.js
@@ -327,12 +327,14 @@ function updateFilterFunction() {
   const conditionStrList = filter.split(' ');
   let conditionObj = {};
   for (const condition of conditionStrList) {
-    let [attribute, requirement] = condition.split(':');
-    if (!attribute || !requirement) {
-      continue; // invalid condition
-    }
-    const [_, operator, value] = requirement.split(/([<>=]+)/);
-    if (!operator || !value) {
+    const attributeRgx = '([a-z]+)';
+    const operatorRgx = '(<=|>=|[<=>])';
+    const valueRgx = '([0-9]{4}-[0-9]{2}-[0-9]{2}|[0-9]+)';
+    const regex = new RegExp(attributeRgx + operatorRgx + valueRgx);
+
+    const matchResult = condition.match(regex);
+    let [attribute, operator, value] = matchResult ? matchResult.slice(1) : [];
+    if (!attribute || !operator || !value) {
       continue; // invalid condition
     }
     if (attribute in mapTable) {

--- a/website/src/settings.js
+++ b/website/src/settings.js
@@ -1,11 +1,9 @@
 const JQ_SETTINGS_POPUP  = $('#uf_settings_popup');
-const JQ_SETTINGS_FILTER = $('#uf_settings_filter');
 const JQ_SETTINGS_CSV    = $('#uf_settings_csv');
 
 
 function openSettingsDialog() {
   ga_openSettings();
-  setAheadFilter();
   setCsvDisplay();
   JQ_SETTINGS_POPUP.addClass('is-active');
 }
@@ -13,27 +11,9 @@ function closeSettingsDialog() {
   JQ_SETTINGS_POPUP.removeClass('is-active');
 }
 function saveSettingsBtnClicked() {
-  saveAheadFilter();
   saveCsvDisplay();
   closeSettingsDialog();
 }
-
-
-/* The "Ahead By Commit Filter" setting. */
-const LOCAL_STORAGE_SETTINGS_AHEAD_FILTER = "useful-forks-ahead-filter";
-let UF_SETTINGS_AHEAD_FILTER;
-function saveAheadFilter() {
-  UF_SETTINGS_AHEAD_FILTER = JQ_SETTINGS_FILTER.val();
-  localStorage.setItem(LOCAL_STORAGE_SETTINGS_AHEAD_FILTER, UF_SETTINGS_AHEAD_FILTER);
-}
-function setAheadFilter() {
-  UF_SETTINGS_AHEAD_FILTER = localStorage.getItem(LOCAL_STORAGE_SETTINGS_AHEAD_FILTER);
-  if (!UF_SETTINGS_AHEAD_FILTER) {
-    UF_SETTINGS_AHEAD_FILTER = 0; // default
-  }
-  JQ_SETTINGS_FILTER.val(UF_SETTINGS_AHEAD_FILTER);
-}
-setAheadFilter();
 
 
 /* The "Export CSV Display" setting. */


### PR DESCRIPTION
There are 2 types of filter: `number` and `date`.
Tyey both support the following operators: `>`, `<`, `>=`, `<=`, `=`.

The format of date should be `yyyy-mm-dd`, like `2022-01-01`.

number: `stars`, `forks`, `ahead`, `behind`.
date: `pushed`

eg: `stars:>0 pushed:>2022-01-01`

---

Example screenshot: 
![image](https://user-images.githubusercontent.com/77615248/218068289-6b85dde8-45e9-400a-8d15-6915ff5c0e85.png)

I have done tests on `payne911/PieMenu` and `Wilfred/difftastic`. It worked well. Certainly it would be better if more checks are taken.

---

It's a little troublesome because I'm more familiar with frameworks like Vue that supporting binding data with DOM, but here we have to update DOM ourselves and somewhere code about data and DOM are mixed.

I only did the necessary refactor to make it possible to add the feature of filtering.

---

And it would be much easier to implement "sort by columns"(#48 ) based on this PR. But I'm not so interested in that 🤔. I would be pleased if anyone would like to do that. Or I can try to solve it in spare time if needed.