### PR TITLE
Ask for token less aggressively

### DIFF
--- a/website/src/token.js
+++ b/website/src/token.js
@@ -35,7 +35,6 @@ function saveTokenBtnClicked() {
 
 function proposeAddingToken() {
   shouldTriggerQueryOnTokenSave = true;
-  openTokenDialog();
 }
 
 function drawAddTokenBtn(accessToken) {


### PR DESCRIPTION
- Close #42

I noticed that a banner is already shown, so it doesn't _also_ need to show a popup.

I should also say that the website is needlessly verbose, both in the banner and in the popup. The core information is just "A token is required to parse the entire fork tree due to GitHub API limits"

<img width="1025" alt="Screenshot" src="https://user-images.githubusercontent.com/1402241/228995640-0b4ac672-2fa5-4793-bf5a-0cb1396673f2.png">

