### PR TITLE
Extension: Change button icon, fix popup and double quote

### DIFF
--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Useful Forks",
-  "version": "2.2.2",
+  "version": "2.2.3",
 
   "description": "To list GitHub forks ordered by stars, with additional information and automatic filtering of irrelevant ones.",
   "icons": {

--- a/plugin/useful-forks.js
+++ b/plugin/useful-forks.js
@@ -1,29 +1,31 @@
 function getRepoUrl() {
-  const pathComponents = window.location.pathname.split('/');
+  const pathComponents = window.location.pathname.split("/");
   const user = pathComponents[1], repo = pathComponents[2];
   return `https://useful-forks.github.io/?repo=${user}/${repo}`;
 }
 
 function setBtnUrl() {
   const button = document.getElementById(UF_BTN_ID);
-  button.addEventListener('click', () => {
-    window.open(getRepoUrl(), '_blank');
+  button.addEventListener("click", () => {
+    window.open(getRepoUrl(), "_blank");
   });
 }
 
 function createUsefulBtn() {
   const li = document.createElement("li");
-  const content = `<div class="float-left">
-                     <button id="${UF_BTN_ID}" class="btn-sm btn" aria-describedby="${UF_TIP_ID}">
-                       <svg height="16" width="16" version="1.1" viewBox="0 0 183.79 183.79" class="octicon octicon-pin mr-1">
-                         <path d="M54.734,9.053C39.12,18.067,27.95,32.624,23.284,50.039c-4.667,17.415-2.271,35.606,6.743,51.22 c12.023,20.823,34.441,33.759,58.508,33.759c7.599,0,15.139-1.308,22.287-3.818l30.364,52.592l21.65-12.5l-30.359-52.583 c10.255-8.774,17.638-20.411,21.207-33.73c4.666-17.415,2.27-35.605-6.744-51.22C134.918,12.936,112.499,0,88.433,0 C76.645,0,64.992,3.13,54.734,9.053z M125.29,46.259c5.676,9.831,7.184,21.285,4.246,32.25c-2.938,10.965-9.971,20.13-19.802,25.806 c-6.462,3.731-13.793,5.703-21.199,5.703c-15.163,0-29.286-8.146-36.857-21.259c-5.676-9.831-7.184-21.284-4.245-32.25 c2.938-10.965,9.971-20.13,19.802-25.807C73.696,26.972,81.027,25,88.433,25C103.597,25,117.719,33.146,125.29,46.259z"></path>
-                       </svg>
-                       Useful
-                     </button>
-                     <tool-tip for="${UF_BTN_ID}" id="${UF_TIP_ID}" class="position-absolute sr-only">
-                       Search for useful forks in a new tab
-                     </tool-tip>
-                   </div>`;
+  const content = `
+  <div class="float-left">
+    <button id="${UF_BTN_ID}" class="btn-sm btn" aria-describedby="${UF_TIP_ID}">
+      <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-search">
+          <path d="M10.68 11.74a6 6 0 0 1-7.922-8.982 6 6 0 0 1 8.982 7.922l3.04 3.04a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215ZM11.5 7a4.499 4.499 0 1 0-8.997 0A4.499 4.499 0 0 0 11.5 7Z"></path>
+      </svg>
+      Useful
+    </button>
+    <tool-tip for="${UF_BTN_ID}" id="${UF_TIP_ID}" popover="manual" class="position-absolute sr-only">
+      Search for useful forks in a new tab
+    </tool-tip>
+  </div>
+  `;
   li.innerHTML = content;
   li.id = UF_LI_ID;
   return li;


### PR DESCRIPTION
Bring UI tweaks to the Chrome extension's in-GitHub button:
- Change the search SVG to GitHub's one (from their new UI, in the top search bar)
- Fix the tooltip not working (anymore?) by adding `popover="manual"` in the button's HTML

Also, change the remaining simple quotes to double quotes for consistency