### PR TITLE
Improve robustness of GitHub repo URL parsing

### DIFF
--- a/website/src/queries-init.js
+++ b/website/src/queries-init.js
@@ -166,15 +166,7 @@ function getQueryOrDefault(defaultVal) {
   if (!JQ_REPO_FIELD.val()) {
     JQ_REPO_FIELD.val(defaultVal);
   }
-
-  const val = JQ_REPO_FIELD.val();
-
-  const isShorthand = /^[\w\.-]+\/[\w\.-]+$/;
-  if (isShorthand.test(val)) {
-    return val; // we are dealing with "user/repo" input format
-  } else {
-    return new URL(val).pathname;
-  }
+  return JQ_REPO_FIELD.val();
 }
 
 function hideFilterContainer() {

--- a/website/src/queries-init.js
+++ b/website/src/queries-init.js
@@ -166,7 +166,15 @@ function getQueryOrDefault(defaultVal) {
   if (!JQ_REPO_FIELD.val()) {
     JQ_REPO_FIELD.val(defaultVal);
   }
-  return JQ_REPO_FIELD.val();
+
+  const val = JQ_REPO_FIELD.val();
+
+  const isShorthand = /^[\w\.-]+\/[\w\.-]+$/;
+  if (isShorthand.test(val)) {
+    return val;
+  } else {
+    return new URL(val).pathname;
+  }
 }
 
 function hideFilterContainer() {

--- a/website/src/queries-init.js
+++ b/website/src/queries-init.js
@@ -169,6 +169,10 @@ function getQueryOrDefault(defaultVal) {
   return JQ_REPO_FIELD.val();
 }
 
+function setQuery(query) {
+  JQ_REPO_FIELD.val(query);
+}
+
 function hideFilterContainer() {
   JQ_FILTER_CONTAINER.hide();
 }

--- a/website/src/queries-init.js
+++ b/website/src/queries-init.js
@@ -171,7 +171,7 @@ function getQueryOrDefault(defaultVal) {
 
   const isShorthand = /^[\w\.-]+\/[\w\.-]+$/;
   if (isShorthand.test(val)) {
-    return val;
+    return val; // we are dealing with "user/repo" input format
   } else {
     return new URL(val).pathname;
   }

--- a/website/src/queries-logic.js
+++ b/website/src/queries-logic.js
@@ -462,8 +462,32 @@ function initial_request(user, repo) {
 }
 
 /** Extracts and sanitizes 'user' and 'repo' values from potential inputs. */
-function initiate_search() {
+function parse_query(queryString) {
+  const shorthand = /^(?<user>[\w.-]+)\/(?<repo>[\w.-]+)$/;
+  const shorthandMatch = shorthand.exec(queryString);
 
+  if (shorthandMatch) { // we are dealing with "user/repo" input format
+    const {user, repo} = shorthandMatch.groups;
+    return {user, repo};
+  }
+
+  let pathname;
+  try {
+    pathname = new URL(queryString).pathname;
+  } catch {
+    return null;
+  }
+
+  const values = pathname.split('/').filter(s => s.length > 0);
+  if (values.length < 2)
+    return null;
+
+  const [user, repo] = values;
+  return {user, repo};
+}
+
+
+function initiate_search() {
   /* Checking if search is allowed. */
   if (searchNotAllowed())
     return; // abort
@@ -471,14 +495,15 @@ function initiate_search() {
   clear_old_data();
 
   let queryString = getQueryOrDefault("payne911/PieMenu");
-  let queryValues = queryString.split('/').filter(s => s.length > 0);
+  const queryValues = parse_query(queryString);
 
-  let len = queryValues.length;
-  if (len < 2) {
+  if (!queryValues) {
     setMsg('Please enter a valid query: it should contain two strings separated by a "/", or the full URL to a GitHub repo');
     ga_faultyQuery(queryString);
     return; // abort
   }
+
+  const {user, repo} = queryValues;
 
   setUpOctokitWithLatestToken();
 
@@ -486,8 +511,6 @@ function initiate_search() {
   hideFilterContainer();
   setMsg(UF_MSG_SCANNING);
 
-  const user = queryValues[0];
-  const repo = queryValues[1];
   if (history.replaceState) {
     history.replaceState({}, document.title, `?repo=${user}/${repo}`); // replace current URL param
   }

--- a/website/src/queries-logic.js
+++ b/website/src/queries-logic.js
@@ -507,6 +507,7 @@ function initiate_search() {
 
   setUpOctokitWithLatestToken();
 
+  setQuery(`${user}/${repo}`);
   setQueryFieldsAsLoading();
   hideFilterContainer();
   setMsg(UF_MSG_SCANNING);

--- a/website/src/queries-logic.js
+++ b/website/src/queries-logic.js
@@ -471,11 +471,11 @@ function initiate_search() {
   clear_old_data();
 
   let queryString = getQueryOrDefault("payne911/PieMenu");
-  let queryValues = queryString.split('/').filter(Boolean);
+  let queryValues = queryString.split('/').filter(s => s.length > 0);
 
   let len = queryValues.length;
   if (len < 2) {
-    setMsg('Please enter a valid query: it should contain two strings separated by a "/"');
+    setMsg('Please enter a valid query: it should contain two strings separated by a "/", or the full URL to a GitHub repo');
     ga_faultyQuery(queryString);
     return; // abort
   }
@@ -486,8 +486,8 @@ function initiate_search() {
   hideFilterContainer();
   setMsg(UF_MSG_SCANNING);
 
-  const user = queryValues[len - 2];
-  const repo = queryValues[len - 1];
+  const user = queryValues[0];
+  const repo = queryValues[1];
   if (history.replaceState) {
     history.replaceState({}, document.title, `?repo=${user}/${repo}`); // replace current URL param
   }


### PR DESCRIPTION
For example this works now: `https://github.com/MichaelAquilina/zsh-auto-notify/pull/67/files`
Previously `67` was taken as the repo owner and `files` as the repo name.
