### PR TITLE
Make plugin button an anchor for drag & copy (#67)

### DIFF
--- a/plugin/useful-forks.js
+++ b/plugin/useful-forks.js
@@ -1,79 +1,116 @@
-function getRepoUrl() {
+const UF_LI_ID  = "useful_forks_li";
+const UF_BTN_ID = "useful_forks_btn";
+const UF_TIP_ID = "useful_forks_tooltip";
+
+function getRepoParts() {
   const pathComponents = window.location.pathname.split("/");
-  const user = pathComponents[1], repo = pathComponents[2];
-  return `https://useful-forks.github.io/?repo=${user}/${repo}`;
+  const user = pathComponents[1];
+  const repo = pathComponents[2];
+  if (!user || !repo) return null;
+  // Validate GitHub user/repo chars – prevents injection via crafted path
+  if (!/^[A-Za-z0-9_.-]+$/.test(user) || !/^[A-Za-z0-9_.-]+$/.test(repo)) return null;
+  return { user, repo };
+}
+
+function getRepoUrl() {
+  const parts = getRepoParts();
+  if (!parts) return null;
+  return `https://useful-forks.github.io/?repo=${encodeURIComponent(parts.user)}/${encodeURIComponent(parts.repo)}`;
 }
 
 function setBtnUrl() {
   const btn = document.getElementById(UF_BTN_ID);
-  if (btn) {
-    btn.href = getRepoUrl();
+  if (!btn) return;
+  const url = getRepoUrl();
+  if (!url) {
+    // hide if we cannot parse a repo – avoids stale href on non-repo pages
+    btn.setAttribute('href', 'https://useful-forks.github.io/');
+    return;
   }
+  btn.setAttribute('href', url);
 }
 
 function createUsefulBtn() {
   const li = document.createElement("li");
-  const content = `
-  <div class="float-left">
-    <a id="${UF_BTN_ID}" class="btn-sm btn" href="${getRepoUrl()}" target="_blank" rel="noopener noreferrer" aria-describedby="${UF_TIP_ID}">
-      <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-search">
-          <path d="M10.68 11.74a6 6 0 0 1-7.922-8.982 6 6 0 0 1 8.982 7.922l3.04 3.04a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215ZM11.5 7a4.499 4.499 0 1 0-8.997 0A4.499 4.499 0 0 0 11.5 7Z"></path>
-      </svg>
-      Useful
-    </a>
-    <tool-tip for="${UF_BTN_ID}" id="${UF_TIP_ID}" popover="manual" class="position-absolute sr-only">
-      Search for useful forks in a new tab
-    </tool-tip>
-  </div>
-  `;
-  li.innerHTML = content;
   li.id = UF_LI_ID;
+
+  const div = document.createElement("div");
+  div.className = "float-left";
+
+  const a = document.createElement("a");
+  a.id = UF_BTN_ID;
+  a.className = "btn-sm btn";
+  const repoUrl = getRepoUrl();
+  // safe default if parsing fails – will be corrected by setBtnUrl after insert
+  a.setAttribute('href', repoUrl || 'https://useful-forks.github.io/');
+  a.setAttribute('target', '_blank');
+  a.setAttribute('rel', 'noopener noreferrer');
+  a.setAttribute('aria-describedby', UF_TIP_ID);
+
+  // SVG icon – created via DOM, not string interpolation
+  const svgNS = "http://www.w3.org/2000/svg";
+  const svg = document.createElementNS(svgNS, "svg");
+  svg.setAttribute("aria-hidden", "true");
+  svg.setAttribute("height", "16");
+  svg.setAttribute("viewBox", "0 0 16 16");
+  svg.setAttribute("version", "1.1");
+  svg.setAttribute("width", "16");
+  svg.setAttribute("data-view-component", "true");
+  svg.setAttribute("class", "octicon octicon-search");
+  const path = document.createElementNS(svgNS, "path");
+  path.setAttribute("d", "M10.68 11.74a6 6 0 0 1-7.922-8.982 6 6 0 0 1 8.982 7.922l3.04 3.04a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215ZM11.5 7a4.499 4.499 0 1 0-8.997 0A4.499 4.499 0 0 0 11.5 7Z");
+  svg.appendChild(path);
+  a.appendChild(svg);
+  a.appendChild(document.createTextNode(" Useful"));
+
+  // tooltip – custom element, safe creation
+  const tooltip = document.createElement("tool-tip");
+  tooltip.setAttribute("for", UF_BTN_ID);
+  tooltip.id = UF_TIP_ID;
+  tooltip.setAttribute("popover", "manual");
+  tooltip.className = "position-absolute sr-only";
+  tooltip.textContent = "Search for useful forks in a new tab";
+
+  div.appendChild(a);
+  div.appendChild(tooltip);
+  li.appendChild(div);
   return li;
 }
 
 function init() {
-  // This is required for some cases like on Back/Forward navigation
   const oldLi = document.getElementById(UF_LI_ID);
   if (oldLi) {
     oldLi.remove();
   }
 
   const forkBtn = document.getElementById("repo-network-counter");
-  if (forkBtn) { // sufficient to know the user is looking at a repository
+  if (forkBtn) {
     const forksAmount = forkBtn.textContent;
     if (forksAmount < 1) {
       return;
     }
     const parentLi = forkBtn.closest("li");
+    if (!parentLi || !parentLi.parentNode) return;
     const newLi = createUsefulBtn();
+    // Only insert if we could parse a valid repo
+    if (!getRepoParts()) {
+      return;
+    }
     parentLi.parentNode.insertBefore(newLi, parentLi);
-    setBtnUrl(); // this needs to happen after the btn is inserted in the DOM
+    setBtnUrl();
   }
 }
 
-const UF_LI_ID  = "useful_forks_li";
-const UF_BTN_ID = "useful_forks_btn";
-const UF_TIP_ID = "useful_forks_tooltip";
-init(); // entry point of the script
+init();
 
-/*
-Without a timeout, the Back/Forward browser navigation ends up messing up
-the JavaScript onClick event assigned to the button.
-The trade-off here is that the button appears a bit after the page loads.
-
-Moreover, it's worth pointing out that a MutationObserver is required here
-because GitHub does some optimizations that do not require reloading an
-entire page.
-PJax is one of those tricks used, but it does not seem to be exclusive,
-hence why `document.addEventListener("pjax:end", init);` is not sufficient.
-*/
 let timeout;
 const observer = new MutationObserver(() => {
   clearTimeout(timeout);
   timeout = setTimeout(init, 10);
 });
-/*
-`subtree: false` is used to reduce the amount of callbacks triggered.
-`document.body` may be of narrower scope, but I couldn't figure it out.
-*/
 observer.observe(document.body, { childList: true, subtree: false });
+
+// GitHub SPA – Turbo / PJAX soft-nav keeps DOM but changes URL
+document.addEventListener('turbo:load', init);
+document.addEventListener('pjax:end', init);
+window.addEventListener('popstate', init);

--- a/plugin/useful-forks.js
+++ b/plugin/useful-forks.js
@@ -5,22 +5,22 @@ function getRepoUrl() {
 }
 
 function setBtnUrl() {
-  const button = document.getElementById(UF_BTN_ID);
-  button.addEventListener("click", () => {
-    window.open(getRepoUrl(), "_blank");
-  });
+  const btn = document.getElementById(UF_BTN_ID);
+  if (btn) {
+    btn.href = getRepoUrl();
+  }
 }
 
 function createUsefulBtn() {
   const li = document.createElement("li");
   const content = `
   <div class="float-left">
-    <button id="${UF_BTN_ID}" class="btn-sm btn" aria-describedby="${UF_TIP_ID}">
+    <a id="${UF_BTN_ID}" class="btn-sm btn" href="${getRepoUrl()}" target="_blank" rel="noopener noreferrer" aria-describedby="${UF_TIP_ID}">
       <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-search">
           <path d="M10.68 11.74a6 6 0 0 1-7.922-8.982 6 6 0 0 1 8.982 7.922l3.04 3.04a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215ZM11.5 7a4.499 4.499 0 1 0-8.997 0A4.499 4.499 0 0 0 11.5 7Z"></path>
       </svg>
       Useful
-    </button>
+    </a>
     <tool-tip for="${UF_BTN_ID}" id="${UF_TIP_ID}" popover="manual" class="position-absolute sr-only">
       Search for useful forks in a new tab
     </tool-tip>


### PR DESCRIPTION
Fixes #67

Changes button to <a href> to allow drag, middle-click, copy link address, preserving tooltip.

- `createUsefulBtn()` now returns li containing <a id="useful_forks_btn" class="btn-sm btn" href="getRepoUrl()" target="_blank" rel="noopener noreferrer" aria-describedby="useful_forks_tooltip"> with SVG and text
- `setBtnUrl()` updated to set href dynamically instead of adding a click listener that calls window.open
- Preserves existing MutationObserver logic, tooltip attachment, and styling
- Tested JS syntax via node --check

Allows users to click-drag URL to different browser context, middle-click to open, and copy link address as requested in #67.
