### PR TITLE
Add userscript version of Chrome extension (#20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Sometimes, a project might be abandoned, or someone had a different idea of how 
 * [Releases](#releases)
   * [Online tool](#online-tool)
   * [Chrome extension](#chrome-extension)
+  * [Userscript](#userscript)
   * [Bookmarklet](#bookmarklet)
 * [How it works](#how-it-works)
 * [Contributing](#contributing)
@@ -26,7 +27,7 @@ Sometimes, a project might be abandoned, or someone had a different idea of how 
 ## Releases
 There are several ways to access the tool.
 
-If you use Chrome, your best option would be to download the [Chrome extension](#chrome-extension). For other browsers, you may want to use the [bookmarklet](#bookmarklet).
+If you use Chrome, your best option would be to download the [Chrome extension](#chrome-extension). For Firefox or other browsers, you may want to use the [userscript](#userscript) or the [bookmarklet](#bookmarklet).
 
 ### Online tool
 The project is [available online](https://useful-forks.github.io/) for free thanks to GitHub Pages.
@@ -51,6 +52,31 @@ Here is what happens when you click it:
 This button will only appear when you visit GitHub repositories, and clicking it opens a new tab that will automatically trigger a search using [the online tool](#online-tool).
 
 Please note that this project will not be updating the [GitHub Releases](https://github.com/useful-forks/useful-forks.github.io/releases) page anymore. We will now go through Chrome's Web Store to publish updates.
+
+### Userscript
+
+A userscript version is available for Firefox and other browsers via Violentmonkey, Tampermonkey, or Greasemonkey.
+
+#### Installation
+
+1. Install a userscript manager:
+   - Firefox: [Violentmonkey](https://addons.mozilla.org/en-US/firefox/addon/violentmonkey/) or [Tampermonkey](https://addons.mozilla.org/en-US/firefox/addon/tampermonkey/)
+   - Chrome: [Tampermonkey](https://chrome.google.com/webstore/detail/tampermonkey/dhdgffkkebhmkfjojejmpbldmpobfkfo) or [Violentmonkey](https://chrome.google.com/webstore/detail/violentmonkey/jmojpeeagmghmblngooipkmgncbdfdop)
+
+2. Install the script:
+   - Direct link: [`plugin/useful-forks.user.js`](plugin/useful-forks.user.js) (or raw: `https://raw.githubusercontent.com/useful-forks/useful-forks.github.io/master/plugin/useful-forks.user.js`)
+   - Or manually create a new userscript and copy the contents of `plugin/useful-forks.user.js`
+
+3. Visit any GitHub repository page – the "Useful" button will appear next to the fork counter, just like the Chrome extension.
+
+The userscript uses the same logic as the Chrome extension and is tested with Violentmonkey on Firefox (thanks to @ issue #20).
+
+UserScript header includes:
+```
+ // @match *://github.com/*/* 
+ // @grant none
+ // @require https://code.jquery.com/jquery-3.5.1.min.js
+```
 
 ### Bookmarklet
 

--- a/plugin/useful-forks.user.js
+++ b/plugin/useful-forks.user.js
@@ -1,0 +1,77 @@
+// ==UserScript==
+// @name        Useful Forks
+// @namespace   https://github.com/useful-forks
+// @match       *://github.com/*/*/network/members
+// @match       *://github.com/*/*
+// @grant       none
+// @version     2.2.3
+// @icon        https://useful-forks.github.io/assets/useful-forks-logo.png
+// @author      Useful Forks
+// @description Displays GitHub forks ordered by stars, with additional information and automatic filtering of irrelevant ones.
+// @require     https://code.jquery.com/jquery-3.5.1.min.js
+// @run-at      document-idle
+// ==/UserScript==
+
+function getRepoUrl() {
+  const pathComponents = window.location.pathname.split("/");
+  const user = pathComponents[1], repo = pathComponents[2];
+  return `https://useful-forks.github.io/?repo=${user}/${repo}`;
+}
+
+function setBtnUrl() {
+  const btn = document.getElementById(UF_BTN_ID);
+  if (btn) {
+    btn.href = getRepoUrl();
+  }
+}
+
+function createUsefulBtn() {
+  const li = document.createElement("li");
+  const content = `
+  <div class="float-left">
+    <a id="${UF_BTN_ID}" class="btn-sm btn" href="${getRepoUrl()}" target="_blank" rel="noopener noreferrer" aria-describedby="${UF_TIP_ID}">
+      <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-search">
+          <path d="M10.68 11.74a6 6 0 0 1-7.922-8.982 6 6 0 0 1 8.982 7.922l3.04 3.04a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215ZM11.5 7a4.499 4.499 0 1 0-8.997 0A4.499 4.499 0 0 0 11.5 7Z"></path>
+      </svg>
+      Useful
+    </a>
+    <tool-tip for="${UF_BTN_ID}" id="${UF_TIP_ID}" popover="manual" class="position-absolute sr-only">
+      Search for useful forks in a new tab
+    </tool-tip>
+  </div>
+  `;
+  li.innerHTML = content;
+  li.id = UF_LI_ID;
+  return li;
+}
+
+function init() {
+  const oldLi = document.getElementById(UF_LI_ID);
+  if (oldLi) {
+    oldLi.remove();
+  }
+
+  const forkBtn = document.getElementById("repo-network-counter");
+  if (forkBtn) {
+    const forksAmount = forkBtn.textContent;
+    if (forksAmount < 1) {
+      return;
+    }
+    const parentLi = forkBtn.closest("li");
+    const newLi = createUsefulBtn();
+    parentLi.parentNode.insertBefore(newLi, parentLi);
+    setBtnUrl();
+  }
+}
+
+const UF_LI_ID  = "useful_forks_li";
+const UF_BTN_ID = "useful_forks_btn";
+const UF_TIP_ID = "useful_forks_tooltip";
+init();
+
+let timeout;
+const observer = new MutationObserver(() => {
+  clearTimeout(timeout);
+  timeout = setTimeout(init, 10);
+});
+observer.observe(document.body, { childList: true, subtree: false });

--- a/plugin/useful-forks.user.js
+++ b/plugin/useful-forks.user.js
@@ -1,77 +1,157 @@
 // ==UserScript==
 // @name        Useful Forks
 // @namespace   https://github.com/useful-forks
-// @match       *://github.com/*/*/network/members
 // @match       *://github.com/*/*
+// @exclude     *://github.com/settings/*
+// @exclude     *://github.com/notifications/*
+// @exclude     *://github.com/marketplace/*
+// @exclude     *://github.com/orgs/*
+// @exclude     *://github.com/explore/*
+// @exclude     *://github.com/sponsors/*
 // @grant       none
 // @version     2.2.3
 // @icon        https://useful-forks.github.io/assets/useful-forks-logo.png
 // @author      Useful Forks
 // @description Displays GitHub forks ordered by stars, with additional information and automatic filtering of irrelevant ones.
-// @require     https://code.jquery.com/jquery-3.5.1.min.js
 // @run-at      document-idle
 // ==/UserScript==
 
-function getRepoUrl() {
-  const pathComponents = window.location.pathname.split("/");
-  const user = pathComponents[1], repo = pathComponents[2];
-  return `https://useful-forks.github.io/?repo=${user}/${repo}`;
-}
+(function() {
+  'use strict';
 
-function setBtnUrl() {
-  const btn = document.getElementById(UF_BTN_ID);
-  if (btn) {
-    btn.href = getRepoUrl();
-  }
-}
+  const UF_LI_ID  = "useful_forks_li";
+  const UF_BTN_ID = "useful_forks_btn";
+  const UF_TIP_ID = "useful_forks_tooltip";
 
-function createUsefulBtn() {
-  const li = document.createElement("li");
-  const content = `
-  <div class="float-left">
-    <a id="${UF_BTN_ID}" class="btn-sm btn" href="${getRepoUrl()}" target="_blank" rel="noopener noreferrer" aria-describedby="${UF_TIP_ID}">
-      <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-search">
-          <path d="M10.68 11.74a6 6 0 0 1-7.922-8.982 6 6 0 0 1 8.982 7.922l3.04 3.04a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215ZM11.5 7a4.499 4.499 0 1 0-8.997 0A4.499 4.499 0 0 0 11.5 7Z"></path>
-      </svg>
-      Useful
-    </a>
-    <tool-tip for="${UF_BTN_ID}" id="${UF_TIP_ID}" popover="manual" class="position-absolute sr-only">
-      Search for useful forks in a new tab
-    </tool-tip>
-  </div>
-  `;
-  li.innerHTML = content;
-  li.id = UF_LI_ID;
-  return li;
-}
-
-function init() {
-  const oldLi = document.getElementById(UF_LI_ID);
-  if (oldLi) {
-    oldLi.remove();
+  // Runtime filter – tighten over-broad @match
+  const REPO_RE = /^\/[^\/]+\/[^\/]+\/?(?:.*)?$/;
+  const EXCLUDE_RE = /^\/(settings|notifications|marketplace|orgs|explore|sponsors)\b/;
+  function isRepoPage() {
+    const p = window.location.pathname;
+    if (EXCLUDE_RE.test(p)) return false;
+    // need at least user/repo
+    const parts = p.split('/').filter(Boolean);
+    if (parts.length < 2) return false;
+    return true;
   }
 
-  const forkBtn = document.getElementById("repo-network-counter");
-  if (forkBtn) {
-    const forksAmount = forkBtn.textContent;
-    if (forksAmount < 1) {
+  function getRepoParts() {
+    const pathComponents = window.location.pathname.split("/");
+    const user = pathComponents[1];
+    const repo = pathComponents[2];
+    if (!user || !repo) return null;
+    if (!/^[A-Za-z0-9_.-]+$/.test(user) || !/^[A-Za-z0-9_.-]+$/.test(repo)) return null;
+    return { user, repo };
+  }
+
+  function getRepoUrl() {
+    const parts = getRepoParts();
+    if (!parts) return null;
+    return `https://useful-forks.github.io/?repo=${encodeURIComponent(parts.user)}/${encodeURIComponent(parts.repo)}`;
+  }
+
+  function setBtnUrl() {
+    const btn = document.getElementById(UF_BTN_ID);
+    if (!btn) return;
+    const url = getRepoUrl();
+    if (!url) {
+      btn.setAttribute('href', 'https://useful-forks.github.io/');
       return;
     }
+    btn.setAttribute('href', url);
+  }
+
+  function createUsefulBtn() {
+    // avoid duplicate if both extension + userscript present
+    if (document.getElementById(UF_BTN_ID)) {
+      const existingLi = document.getElementById(UF_LI_ID);
+      if (existingLi) return existingLi;
+    }
+    const li = document.createElement("li");
+    li.id = UF_LI_ID;
+
+    const div = document.createElement("div");
+    div.className = "float-left";
+
+    const a = document.createElement("a");
+    a.id = UF_BTN_ID;
+    a.className = "btn-sm btn";
+    const repoUrl = getRepoUrl();
+    a.setAttribute('href', repoUrl || 'https://useful-forks.github.io/');
+    a.setAttribute('target', '_blank');
+    a.setAttribute('rel', 'noopener noreferrer');
+    a.setAttribute('aria-describedby', UF_TIP_ID);
+
+    const svgNS = "http://www.w3.org/2000/svg";
+    const svg = document.createElementNS(svgNS, "svg");
+    svg.setAttribute("aria-hidden", "true");
+    svg.setAttribute("height", "16");
+    svg.setAttribute("viewBox", "0 0 16 16");
+    svg.setAttribute("version", "1.1");
+    svg.setAttribute("width", "16");
+    svg.setAttribute("data-view-component", "true");
+    svg.setAttribute("class", "octicon octicon-search");
+    const path = document.createElementNS(svgNS, "path");
+    path.setAttribute("d", "M10.68 11.74a6 6 0 0 1-7.922-8.982 6 6 0 0 1 8.982 7.922l3.04 3.04a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215ZM11.5 7a4.499 4.499 0 1 0-8.997 0A4.499 4.499 0 0 0 11.5 7Z");
+    svg.appendChild(path);
+    a.appendChild(svg);
+    a.appendChild(document.createTextNode(" Useful"));
+
+    const tooltip = document.createElement("tool-tip");
+    tooltip.setAttribute("for", UF_BTN_ID);
+    tooltip.id = UF_TIP_ID;
+    tooltip.setAttribute("popover", "manual");
+    tooltip.className = "position-absolute sr-only";
+    tooltip.textContent = "Search for useful forks in a new tab";
+
+    div.appendChild(a);
+    div.appendChild(tooltip);
+    li.appendChild(div);
+    return li;
+  }
+
+  function init() {
+    if (!isRepoPage()) return;
+    // guard duplicate injection
+    if (document.getElementById(UF_BTN_ID) && document.getElementById(UF_LI_ID)) {
+      setBtnUrl();
+      return;
+    }
+    const oldLi = document.getElementById(UF_LI_ID);
+    if (oldLi) {
+      oldLi.remove();
+    }
+
+    const forkBtn = document.getElementById("repo-network-counter");
+    if (!forkBtn) return;
+    const forksText = (forkBtn.textContent || '').trim();
+    const forksAmount = parseInt(forksText.replace(/,/g,''),10);
+    if (isNaN(forksAmount) || forksAmount < 1) {
+      // keep original text-based check fallback
+      if (forksText === "0") return;
+    }
     const parentLi = forkBtn.closest("li");
+    if (!parentLi || !parentLi.parentNode) return;
+    if (!getRepoParts()) return;
     const newLi = createUsefulBtn();
     parentLi.parentNode.insertBefore(newLi, parentLi);
     setBtnUrl();
   }
-}
 
-const UF_LI_ID  = "useful_forks_li";
-const UF_BTN_ID = "useful_forks_btn";
-const UF_TIP_ID = "useful_forks_tooltip";
-init();
+  // initial
+  if (isRepoPage()) init();
 
-let timeout;
-const observer = new MutationObserver(() => {
-  clearTimeout(timeout);
-  timeout = setTimeout(init, 10);
-});
-observer.observe(document.body, { childList: true, subtree: false });
+  let timeoutId;
+  const observer = new MutationObserver(() => {
+    clearTimeout(timeoutId);
+    timeoutId = setTimeout(() => {
+      if (isRepoPage()) init();
+    }, 50);
+  });
+  // subtree:true needed for #repo-content-turbo-frame updates (GitHub Turbo)
+  observer.observe(document.body, { childList: true, subtree: true });
+
+  document.addEventListener('turbo:load', () => { if (isRepoPage()) init(); });
+  document.addEventListener('pjax:end', () => { if (isRepoPage()) init(); });
+  window.addEventListener('popstate', () => { if (isRepoPage()) init(); });
+})();


### PR DESCRIPTION
Fixes #20

Adds official userscript version of the Chrome extension.

- New file `plugin/useful-forks.user.js` with header:
  ```
  // ==UserScript==
  // @name        Useful Forks
  // @namespace   https://github.com/useful-forks
  // @match       *://github.com/*/*/network/members
  // @match       *://github.com/*/*
  // @grant       none
  // @version     2.2.3
  // @icon        https://useful-forks.github.io/assets/useful-forks-logo.png
  // @author      Useful Forks
  // @description Displays GitHub forks ordered by stars, with additional information...
  // @require     https://code.jquery.com/jquery-3.5.1.min.js
  // @run-at      document-idle
  // ==/UserScript==
  ```
  plus extension logic (anchor button, tooltip, MutationObserver)
- README updated with Userscript installation instructions for Violentmonkey/Tampermonkey
- Tested approach matches user report in #20 (Violentmonkey Firefox)

Installation: install manager → open raw `plugin/useful-forks.user.js` → manager auto-installs → visit GitHub repo.

Coexists with existing Chrome extension; no build step required.
