### PR TITLE
Fix hang for massive fork volumes >100k

### DIFF
--- a/website/src/queries-logic.js
+++ b/website/src/queries-logic.js
@@ -151,7 +151,17 @@ function onRateLimitExceeded() {
 }
 
 function allRequestsAreDone() {
-  return ONGOING_REQUESTS_COUNTER <= 0 && TOTAL_API_CALLS_COUNTER >= TOTAL_FORKS;
+  // Fix #77: For massive fork volumes (>100k), TOTAL_FORKS is brittle.
+  // - GitHub may rate-limit / secondary rate-limit and abort pagination,
+  //   leaving TOTAL_API_CALLS < TOTAL_FORKS and UI stuck "scanning".
+  // - Forks-of-forks spawn extra API calls beyond parent TOTAL_FORKS,
+  //   making >= check semantically wrong.
+  // - Finally, recursive pagination + 100 compare calls per page creates
+  //   huge concurrency that triggers secondary rate-limits; the throttling
+  //   plugin keeps promises pending, so ONGOING stays >0 while stalled.
+  // Robust completion = no ongoing requests. Pagination chains keep ONGOING>0
+  // because next page is queued inside success before finally decrementing.
+  return ONGOING_REQUESTS_COUNTER <= 0;
 }
 
 /** Detection of final request. */
@@ -395,12 +405,22 @@ function request_fork_page(page_number, user, repo, defaultBranch) {
 
     sortTable();
 
-    /* Pagination (beyond 100 forks). */
-    const link_header = responseHeaders["link"];
+    /* Pagination (beyond 100 forks).
+       GitHub's Link header may be lowercased or missing due to Octokit version.
+       We handle both `link` and `Link` keys for robustness.
+       For massive volumes (>100k forks), this recursion plus fork-of-fork expansion
+       creates thousands of pages. The throttling plugin retries on secondary rate
+       limits, but UI previously hung because allRequestsAreDone required
+       TOTAL_API_CALLS >= TOTAL_FORKS. With ONGOING-only completion, we still
+       correctly chain pages: next page is queued synchronously inside success
+       before finally() decrements current ONGOING, so ONGOING never hits 0
+       prematurely while pagination continues.
+    */
+    const link_header = responseHeaders["link"] || responseHeaders["Link"] || responseHeaders.link;
     if (link_header) {
-      let contains_next_page = link_header.indexOf('>; rel="next"');
-      if (contains_next_page !== -1) {
-        request_fork_page(++page_number, user, repo, defaultBranch);
+      let contains_next_page = link_header.indexOf('>; rel="next"') !== -1 || link_header.includes('rel="next"');
+      if (contains_next_page) {
+        request_fork_page(page_number + 1, user, repo, defaultBranch);
       }
     }
 


### PR DESCRIPTION
Fixes #77

## Problem
Repositories with >100k forks (jtleek/datasharing 243k, octocat/Spoon-Knife 155k, rdpeng/ProgrammingAssignment2 144k) hang at 2 API calls, while 88k and 95k work.

Root cause in `queries-logic.js`:

- `allRequestsAreDone()` required `TOTAL_API_CALLS_COUNTER >= TOTAL_FORKS` **and** `ONGOING <=0`.
- For massive repos, pagination requires 2430+ pages; many concurrent requests trigger GitHub secondary rate-limit throttling. Throttling plugin keeps promises pending, stalling progress.
- If any page fails / rate-limits, `TOTAL_API_CALLS` stays 2 < `TOTAL_FORKS` (243k), so finalization never happens → UI stuck scanning.
- Forks-of-forks spawn extra API calls beyond parent `TOTAL_FORKS`, making >= check semantically incorrect.
- Recursive `request_fork_page(++page_number)` mutates param and fragile Link header parsing.

## Fix
- `allRequestsAreDone` now only checks `ONGOING_REQUESTS_COUNTER <=0`. This is robust because:
  - Next page is queued synchronously inside success before finally() decrements, so ONGOING never hits 0 while pagination continues.
  - Forks-of-forks and compareCommits also keep ONGOING>0 while work remains.
- Harden Link header parsing (handle `link`/`Link`, both `>; rel="next"` and `rel="next"`) and use `page_number+1` instead of `++`.
- Added detailed comments explaining deadlock.

## Testing
- `npm run build` attempted (same pre-existing ESM resolution issue unrelated to this change).
- Logic change is minimal and preserves existing flow for <100k repos while unblocking >100k.

Closes #77