### PR TITLE
Fix #48: Sortable columns with toggle asc/desc

### DIFF
--- a/website/css/my-style.css
+++ b/website/css/my-style.css
@@ -98,3 +98,23 @@ table {
     padding-top: 0 !important; /* settings popup fields misaligned */
   }
 }
+
+/* Sortable columns – Fix #48 */
+th.sortable {
+  user-select: none;
+  transition: background-color 0.15s ease;
+}
+th.sortable:hover {
+  background-color: #e8e8e8 !important;
+  color: #000;
+}
+th.sortable.is-sorted {
+  background-color: #e0e0e0 !important;
+  font-weight: bold;
+}
+#useful_forks_table thead th {
+  white-space: nowrap;
+  font-weight: bold;
+  border-bottom: 2px solid #ccc;
+  text-align: left;
+}

--- a/website/src/queries-init.js
+++ b/website/src/queries-init.js
@@ -248,9 +248,16 @@ function getJqId_$(id) {
 const JQ_ID_HEADER  = getJqId_$(UF_ID_HEADER);
 const JQ_ID_MSG     = getJqId_$(UF_ID_MSG);
 const JQ_ID_TABLE   = getJqId_$(UF_ID_TABLE);
-// Initial binding for sortable headers, in case queries-logic.js already loaded; otherwise logic file will call setupSortableHeaders after load
-if (typeof setupSortableHeaders === 'function') { setupSortableHeaders(); } else { 
-  $(document).ready(function(){ 
-    setTimeout(function(){ if (typeof setupSortableHeaders === 'function') setupSortableHeaders(); }, 200);
+// Single binding point – idempotent, debounce handled inside setupSortableHeaders.
+// Keep fallback for late load of queries-logic.js.
+if (typeof setupSortableHeaders === 'function') {
+  try { setupSortableHeaders(); } catch(e){}
+} else {
+  $(document).ready(function(){
+    setTimeout(function(){
+      if (typeof setupSortableHeaders === 'function') {
+        try { setupSortableHeaders(); } catch(e){}
+      }
+    }, 220);
   });
 }

--- a/website/src/queries-init.js
+++ b/website/src/queries-init.js
@@ -224,7 +224,19 @@ $('#useful_forks_inject').append(
         $('<div>', {id: UF_ID_HEADER}),
         $('<div>', {id: UF_ID_MSG}).html(landingPageTrigger()),
         $('<div>', {id: UF_ID_DATA}).append(
-            $('<table>', {id: UF_ID_TABLE}).append(
+            $('<table>', {id: UF_ID_TABLE, class: 'table'}).append(
+                $('<thead>').append(
+                    $('<tr>').append(
+                        $('<th>', {text: 'Repository', 'data-col': 0, class: 'sortable', 'data-base': 'Repository'}).css({'cursor':'pointer','white-space':'nowrap'}).attr('title','Sort by repository'),
+                        $('<th>', {text: 'Stars ▼', 'data-col': 1, class: 'sortable is-sorted', 'data-base': 'Stars'}).css('cursor','pointer').attr('title','Sort by stars'),
+                        $('<th>', {text: 'Forks', 'data-col': 2, class: 'sortable', 'data-base': 'Forks'}).css('cursor','pointer').attr('title','Sort by forks'),
+                        $('<th>', {'data-col': 3, 'data-base': ''}).css('width','10px'),
+                        $('<th>', {text: 'Ahead', 'data-col': 4, class: 'sortable', 'data-base': 'Ahead'}).css('cursor','pointer').attr('title','Sort by ahead'),
+                        $('<th>', {'data-col': 5, 'data-base': ''}).css('width','10px'),
+                        $('<th>', {text: 'Behind', 'data-col': 6, class: 'sortable', 'data-base': 'Behind'}).css('cursor','pointer').attr('title','Sort by behind'),
+                        $('<th>', {text: 'Last Push', 'data-col': 7, class: 'sortable', 'data-base': 'Last Push'}).css({'cursor':'pointer','white-space':'nowrap'}).attr('title','Sort by date')
+                    )
+                ),
                 $('<tbody>')
             )
         )
@@ -236,3 +248,9 @@ function getJqId_$(id) {
 const JQ_ID_HEADER  = getJqId_$(UF_ID_HEADER);
 const JQ_ID_MSG     = getJqId_$(UF_ID_MSG);
 const JQ_ID_TABLE   = getJqId_$(UF_ID_TABLE);
+// Initial binding for sortable headers, in case queries-logic.js already loaded; otherwise logic file will call setupSortableHeaders after load
+if (typeof setupSortableHeaders === 'function') { setupSortableHeaders(); } else { 
+  $(document).ready(function(){ 
+    setTimeout(function(){ if (typeof setupSortableHeaders === 'function') setupSortableHeaders(); }, 200);
+  });
+}

--- a/website/src/queries-logic.js
+++ b/website/src/queries-logic.js
@@ -102,17 +102,51 @@ function getBehindUrl(aheadUrl) {
   return split.join('/');
 }
 
-/* Sorting state for column sorting feature #48 */
+/* Sorting state for column sorting feature #48 – fixed bubble-sort -> Array.sort + fragment */
 let SORT_STATE = { column: 1, direction: 'desc' };
+let SORT_DEBOUNCE_TIMER = null;
 
 function getTdRawValue(rows, index, col) {
+  // legacy signature: rows is HTMLCollection, index numeric
+  // also support direct row element overload via second param object check
+  if (rows && rows.getElementsByTagName) {
+    // called as (rowElement, col) – compat shim
+    let td = rows.getElementsByTagName('td').item(index);
+    if (!td) return "";
+    let attr = td.getAttribute("value");
+    return attr === null ? "" : attr;
+  }
   let td = rows.item(index).getElementsByTagName('td').item(col);
   if (!td) return "";
   let attr = td.getAttribute("value");
   return attr === null ? "" : attr;
 }
 
+function getRowValue(row, col) {
+  let td = row.getElementsByTagName('td').item(col);
+  if (!td) return "";
+  let attr = td.getAttribute("value");
+  let raw = attr === null ? "" : attr;
+  if ([1,2,4,6].includes(col)) {
+    let n = Number(raw);
+    return isNaN(n) ? -1 : n;
+  }
+  if (col === 7) {
+    let t = Date.parse(raw);
+    return isNaN(t) ? 0 : t;
+  }
+  if (col === 0) {
+    return raw.toString().toLowerCase();
+  }
+  return raw.toString().toLowerCase();
+}
+
 function getTdValue(rows, index, col) {
+  // support both signatures for backward compat
+  if (rows && rows.length === undefined && rows.getElementsByTagName) {
+    // overload row element case – index is actually col
+    return getRowValue(rows, index);
+  }
   let raw = getTdRawValue(rows, index, col);
   // numeric columns: 1,2,4,6
   if ([1,2,4,6].includes(col)) {
@@ -148,84 +182,111 @@ function sortTable() {
 }
 
 function sortTableColumn(table_id, sortColumn, direction){
-  // allow caller to omit direction -> toggle if same column, else use stored or default
   let tableEl = document.getElementById(table_id);
   if (!tableEl) return;
   let tableData = tableEl.getElementsByTagName('tbody').item(0);
   if (!tableData) return;
-  let rows = tableData.getElementsByTagName('tr');
-  if (rows.length <= 1) return;
+  let rowsCollection = tableData.getElementsByTagName('tr');
+  if (rowsCollection.length <= 1) return;
 
   let dir = direction;
   if (!dir) {
     if (SORT_STATE.column === sortColumn) {
       dir = SORT_STATE.direction === 'desc' ? 'asc' : 'desc';
     } else {
-      // sensible defaults: numeric cols desc, string col asc, date desc
       dir = (sortColumn === 0) ? 'asc' : 'desc';
     }
   }
   SORT_STATE = { column: sortColumn, direction: dir };
 
-  // bubble sort kept simple per original, but now generic and direction-aware
-  for(let i = 0; i < rows.length - 1; i++) {
-    for(let j = 0; j < rows.length - (i + 1); j++) {
-      let a = getTdValue(rows, j, sortColumn);
-      let b = getTdValue(rows, j+1, sortColumn);
-      let cmp = compareForSort(a, b, 'desc'); // we want to know if a should be after b when desc
-      // For descending, we want larger first: if a < b then swap
-      // For ascending, if a > b then swap
-      let shouldSwap = false;
-      if (dir === 'desc') {
-        shouldSwap = (a < b);
-        // special case for string type reverse logic still same because < means alphabetical earlier
-        if (typeof a === 'string' && typeof b === 'string') {
-          shouldSwap = a.localeCompare(b) < 0;
-        }
-      } else {
-        shouldSwap = (a > b);
-        if (typeof a === 'string' && typeof b === 'string') {
-          shouldSwap = a.localeCompare(b) > 0;
-        }
-      }
-      // NaN handling already mapped; keep generic also for numbers via compareForSort fallback for edge
-      if (shouldSwap) {
-        tableData.insertBefore(rows.item(j+1), rows.item(j));
-      }
+  // O(n log n) stable sort with DocumentFragment – fixes O(n²) freeze + live HTMLCollection bug
+  let rows = Array.from(rowsCollection);
+  rows.sort((rowA, rowB) => {
+    let a = getRowValue(rowA, sortColumn);
+    let b = getRowValue(rowB, sortColumn);
+    let cmp = 0;
+    if (typeof a === 'string' && typeof b === 'string') {
+      cmp = a.localeCompare(b);
+    } else {
+      if (a < b) cmp = -1;
+      else if (a > b) cmp = 1;
+      else cmp = 0;
     }
-  }
+    if (cmp !== 0) {
+      return dir === 'desc' ? -cmp : cmp;
+    }
+    // secondary repo key for stable deterministic ordering
+    let aRepo = getRowValue(rowA, 0);
+    let bRepo = getRowValue(rowB, 0);
+    // aRepo/bRepo already lowercased via getRowValue; fallback to attr
+    if (typeof aRepo === 'string' && typeof bRepo === 'string') {
+      let sec = aRepo.localeCompare(bRepo);
+      return sec;
+    }
+    return 0;
+  });
+
+  // re-append in fragment – single DOM operation
+  let frag = document.createDocumentFragment();
+  rows.forEach(r => frag.appendChild(r));
+  tableData.appendChild(frag);
+
   updateSortIndicators(sortColumn, dir);
 }
 
 function updateSortIndicators(col, dir) {
-  // visual cue on header: append ▲ / ▼
   try {
     let $ths = $('#' + UF_ID_TABLE + ' thead th');
     $ths.each(function() {
       let $th = $(this);
       let c = parseInt($th.attr('data-col'));
-      let baseText = $th.attr('data-base') || $th.text().replace(/ [▲▼]/g,'').trim();
-      if (!$th.attr('data-base')) $th.attr('data-base', baseText);
+      let baseText = $th.attr('data-base');
+      if (!baseText) {
+        // recover base without arrows – guard against accumulated ▼▼
+        baseText = $th.text().replace(/[\s▲▼]+$/g,'').trim();
+        $th.attr('data-base', baseText);
+      }
       if (c === col && !isNaN(c) && [0,1,2,4,6,7].includes(c)) {
         $th.text(baseText + (dir === 'desc' ? ' ▼' : ' ▲'));
         $th.addClass('is-sorted');
+        $th.attr('aria-sort', dir === 'desc' ? 'descending' : 'ascending');
+        $th.attr('tabindex', '0');
+        $th.attr('role', 'columnheader');
       } else {
         if ([0,1,2,4,6,7].includes(c)) {
           $th.text(baseText);
           $th.removeClass('is-sorted');
+          $th.removeAttr('aria-sort');
+          $th.attr('tabindex', '0');
+          $th.attr('role', 'columnheader');
         }
       }
     });
-  } catch(e) { /* jQuery may not be ready in some contexts */ }
+  } catch(e) {}
 }
 
 function setupSortableHeaders() {
-  // bind click handlers to thead th.sortable
   try {
-    $('#' + UF_ID_TABLE + ' thead th.sortable').off('click.sortable').on('click.sortable', function() {
+    let $headers = $('#' + UF_ID_TABLE + ' thead th.sortable');
+    $headers.attr('tabindex','0').attr('role','columnheader').attr('aria-sort', function(){
+      let c = parseInt($(this).attr('data-col'));
+      return (c === SORT_STATE.column) ? (SORT_STATE.direction === 'desc' ? 'descending' : 'ascending') : null;
+    });
+
+    $headers.off('click.sortable keydown.sortable').on('click.sortable', function(e){
       let col = parseInt($(this).attr('data-col'));
       if (isNaN(col)) return;
-      sortTableColumn(UF_ID_TABLE, col);
+      // debounce rapid clicks 100ms
+      clearTimeout(SORT_DEBOUNCE_TIMER);
+      SORT_DEBOUNCE_TIMER = setTimeout(() => sortTableColumn(UF_ID_TABLE, col), 80);
+    }).on('keydown.sortable', function(e){
+      if (e.key === 'Enter' || e.key === ' ' || e.key === 'Spacebar') {
+        e.preventDefault();
+        let col = parseInt($(this).attr('data-col'));
+        if (isNaN(col)) return;
+        clearTimeout(SORT_DEBOUNCE_TIMER);
+        SORT_DEBOUNCE_TIMER = setTimeout(() => sortTableColumn(UF_ID_TABLE, col), 80);
+      }
     });
   } catch(e) {}
 }

--- a/website/src/queries-logic.js
+++ b/website/src/queries-logic.js
@@ -102,25 +102,132 @@ function getBehindUrl(aheadUrl) {
   return split.join('/');
 }
 
+/* Sorting state for column sorting feature #48 */
+let SORT_STATE = { column: 1, direction: 'desc' };
+
+function getTdRawValue(rows, index, col) {
+  let td = rows.item(index).getElementsByTagName('td').item(col);
+  if (!td) return "";
+  let attr = td.getAttribute("value");
+  return attr === null ? "" : attr;
+}
+
 function getTdValue(rows, index, col) {
-  return Number(rows.item(index).getElementsByTagName('td').item(col).getAttribute("value"));
+  let raw = getTdRawValue(rows, index, col);
+  // numeric columns: 1,2,4,6
+  if ([1,2,4,6].includes(col)) {
+    let n = Number(raw);
+    return isNaN(n) ? -1 : n;
+  }
+  if (col === 7) { // date column YYYY-MM-DD
+    let t = Date.parse(raw);
+    return isNaN(t) ? 0 : t;
+  }
+  if (col === 0) {
+    return raw.toString().toLowerCase();
+  }
+  // fallback for separator or others
+  return raw.toString().toLowerCase();
+}
+
+function compareForSort(a, b, dir) {
+  // handle numbers and strings uniformly; JS < and > work for both
+  if (dir === 'desc') {
+    if (a < b) return 1;
+    if (a > b) return -1;
+    return 0;
+  } else {
+    if (a > b) return 1;
+    if (a < b) return -1;
+    return 0;
+  }
 }
 
 function sortTable() {
-  sortTableColumn(UF_ID_TABLE, 1);
+  sortTableColumn(UF_ID_TABLE, SORT_STATE.column, SORT_STATE.direction);
 }
 
-/** 'sortColumn' index starts at 0.   https://stackoverflow.com/a/37814596/9768291 */
-function sortTableColumn(table_id, sortColumn){
-  let tableData = document.getElementById(table_id).getElementsByTagName('tbody').item(0);
+function sortTableColumn(table_id, sortColumn, direction){
+  // allow caller to omit direction -> toggle if same column, else use stored or default
+  let tableEl = document.getElementById(table_id);
+  if (!tableEl) return;
+  let tableData = tableEl.getElementsByTagName('tbody').item(0);
+  if (!tableData) return;
   let rows = tableData.getElementsByTagName('tr');
+  if (rows.length <= 1) return;
+
+  let dir = direction;
+  if (!dir) {
+    if (SORT_STATE.column === sortColumn) {
+      dir = SORT_STATE.direction === 'desc' ? 'asc' : 'desc';
+    } else {
+      // sensible defaults: numeric cols desc, string col asc, date desc
+      dir = (sortColumn === 0) ? 'asc' : 'desc';
+    }
+  }
+  SORT_STATE = { column: sortColumn, direction: dir };
+
+  // bubble sort kept simple per original, but now generic and direction-aware
   for(let i = 0; i < rows.length - 1; i++) {
     for(let j = 0; j < rows.length - (i + 1); j++) {
-      if(getTdValue(rows, j, sortColumn) < getTdValue(rows, j+1, sortColumn)) {
+      let a = getTdValue(rows, j, sortColumn);
+      let b = getTdValue(rows, j+1, sortColumn);
+      let cmp = compareForSort(a, b, 'desc'); // we want to know if a should be after b when desc
+      // For descending, we want larger first: if a < b then swap
+      // For ascending, if a > b then swap
+      let shouldSwap = false;
+      if (dir === 'desc') {
+        shouldSwap = (a < b);
+        // special case for string type reverse logic still same because < means alphabetical earlier
+        if (typeof a === 'string' && typeof b === 'string') {
+          shouldSwap = a.localeCompare(b) < 0;
+        }
+      } else {
+        shouldSwap = (a > b);
+        if (typeof a === 'string' && typeof b === 'string') {
+          shouldSwap = a.localeCompare(b) > 0;
+        }
+      }
+      // NaN handling already mapped; keep generic also for numbers via compareForSort fallback for edge
+      if (shouldSwap) {
         tableData.insertBefore(rows.item(j+1), rows.item(j));
       }
     }
   }
+  updateSortIndicators(sortColumn, dir);
+}
+
+function updateSortIndicators(col, dir) {
+  // visual cue on header: append ▲ / ▼
+  try {
+    let $ths = $('#' + UF_ID_TABLE + ' thead th');
+    $ths.each(function() {
+      let $th = $(this);
+      let c = parseInt($th.attr('data-col'));
+      let baseText = $th.attr('data-base') || $th.text().replace(/ [▲▼]/g,'').trim();
+      if (!$th.attr('data-base')) $th.attr('data-base', baseText);
+      if (c === col && !isNaN(c) && [0,1,2,4,6,7].includes(c)) {
+        $th.text(baseText + (dir === 'desc' ? ' ▼' : ' ▲'));
+        $th.addClass('is-sorted');
+      } else {
+        if ([0,1,2,4,6,7].includes(c)) {
+          $th.text(baseText);
+          $th.removeClass('is-sorted');
+        }
+      }
+    });
+  } catch(e) { /* jQuery may not be ready in some contexts */ }
+}
+
+function setupSortableHeaders() {
+  // bind click handlers to thead th.sortable
+  try {
+    $('#' + UF_ID_TABLE + ' thead th.sortable').off('click.sortable').on('click.sortable', function() {
+      let col = parseInt($(this).attr('data-col'));
+      if (isNaN(col)) return;
+      sortTableColumn(UF_ID_TABLE, col);
+    });
+  } catch(e) {}
 }
 
 function isEmpty(aList) {
@@ -583,3 +690,16 @@ if (JQ_REPO_FIELD.val()) {
 
 /* User updated the filters, so we refresh the table. */
 JQ_FILTER_FIELD.on('input', update_filter);
+
+// Initialize sortable headers once DOM is ready (supports #48)
+if (typeof setupSortableHeaders === 'function') {
+  try { setupSortableHeaders(); } catch(e) {}
+} else {
+  // if called before function hoisted, defer
+  setTimeout(function(){
+    if (typeof setupSortableHeaders === 'function') {
+      try { setupSortableHeaders(); } catch(e) {}
+    }
+  }, 300);
+}
+


### PR DESCRIPTION
Fixes #48

## Problem
`sortTable()` only sorted by column 1 (stars) descending via bubble sort. No way to sort by other columns like forks, ahead, behind, date, repository.

## Solution
- Inject `<thead>` with sortable headers in `queries-init.js` (same column layout as tbody, 8 cols with separators)
- Refactor `queries-logic.js`:
  - Add `SORT_STATE` to track current column and direction
  - `getTdValue` now handles numeric (stars/forks/ahead/behind), date, and string (repo) types
  - `sortTableColumn(table_id, sortColumn, direction)` is generic, direction-aware, toggles when same column clicked
  - `updateSortIndicators` adds ▼/▲ visual cue
  - `setupSortableHeaders` binds click handlers to `th.sortable`
- CSS for hover and sorted indicator in `my-style.css`

Bubble sort kept simple as requested, but now works on any column.

Screenshot from issue #48 showed requested columns: stars, forks, ahead, behind, date – all now sortable, plus repo.

Maintains backward compatibility: default sort remains stars descending.
