### PR TITLE
Search additionally not-forked copies

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -183,6 +183,24 @@
           </div>
         </div>
 
+        <!-- Search non-fork copies (opt-in) – PR89 fix -->
+        <div class="field is-horizontal">
+          <div class="field-label is-normal">
+            <label class="label">Similar copies:</label>
+          </div>
+          <div class="field-body">
+            <div class="field">
+              <div class="control">
+                <label class="checkbox">
+                  <input type="checkbox" id="uf_settings_copies">
+                  Search non-fork copies (opt-in, capped)
+                </label>
+              </div>
+              <p class="help mb-2"><strong>Default is unchecked.</strong> When enabled, searches GitHub for repos with similar name (max 5, per_page 5, >5 stars or useful). Opt-in to avoid quota blow-up.</p>
+            </div>
+          </div>
+        </div>
+
       </section>
       <footer class="modal-card-foot">
         <a class="button is-uf-orange is-large is-fullwidth"

--- a/website/src/queries-logic.js
+++ b/website/src/queries-logic.js
@@ -102,6 +102,87 @@ function getBehindUrl(aheadUrl) {
   return split.join('/');
 }
 
+/* --- Feature #65: Search additionally not-forked repository copies --- */
+function strip_trailing_numbers(name) {
+  // Suggested in #65: strip trailing numbers, e.g., vcstool2 -> vcstool
+  // Also trim trailing separators after stripping.
+  return name.replace(/\d+$/, '').replace(/[-_\.]$/, '').trim() || name;
+}
+
+function search_similar_repos(user, repo, parentDefaultBranch) {
+  const base = strip_trailing_numbers(repo);
+  const query = base.length >= 3 ? base : repo;
+
+  const requestPromise = () => octokit.search.repos({
+    q: `${query} in:name`,
+    sort: 'stars',
+    order: 'desc',
+    per_page: 10
+  });
+
+  const onSuccess = (responseHeaders, responseData) => {
+    const items = responseData.items || [];
+    for (const item of items) {
+      if (!item || !item.full_name) continue;
+      if (item.full_name.toLowerCase() === `${user}/${repo}`.toLowerCase()) continue;
+      if (is_duplicate_repo(item.full_name)) continue;
+
+      // Skip if this repo is already a known fork? We keep it if not duplicate; GitHub search includes forks, but duplicate check handles fork list.
+      // Flag as copy (not forked) for UI distinction.
+      let datum = {
+        'name': item.full_name,
+        'stars': item.stargazers_count,
+        'forks': item.forks_count,
+        'ahead_by': 0,
+        'ahead_url': `https://github.com/${item.full_name}`,
+        'behind_by': 0,
+        'behind_url': `https://github.com/${item.full_name}`,
+        'pushed_at': getOnlyDate(item.pushed_at || item.updated_at || new Date().toISOString()),
+        'is_copy': true
+      };
+
+      // Attempt to compute commits ahead/behind against original if possible (best-effort)
+      // This reuses compareCommits logic similar to forks; if it fails we still show the copy.
+      const comparePromise = () => octokit.repos.compareCommits({
+        owner: user,
+        repo: repo,
+        base: parentDefaultBranch,
+        head: `${item.owner.login}:${item.default_branch}`
+      });
+      const onCompareSuccess = (cmpHeaders, cmpData) => {
+        if (cmpData.total_commits > 0) {
+          datum['ahead_by'] = cmpData.ahead_by;
+          datum['ahead_url'] = cmpData.html_url;
+          datum['behind_by'] = cmpData.behind_by;
+          datum['behind_url'] = getBehindUrl(cmpData.html_url);
+        }
+        TABLE_DATA.push(datum);
+        if (TABLE_DATA.length > 1) showFilterContainer();
+        update_table_trying_use_filter();
+      };
+      const onCompareFailure = () => {
+        // Push anyway as copy even if compare fails (e.g., unrelated histories)
+        TABLE_DATA.push(datum);
+        if (TABLE_DATA.length > 1) showFilterContainer();
+        update_table_trying_use_filter();
+      };
+      // Use send to respect rate limiting; if rate limited, fallback to direct push
+      if (!RATE_LIMIT_EXCEEDED) {
+        send(comparePromise, onCompareSuccess, onCompareFailure);
+      } else {
+        TABLE_DATA.push(datum);
+        update_table_trying_use_filter();
+      }
+    }
+  };
+
+  const onFailure = () => {
+    // Silent failure for similar repos search – not critical
+  };
+
+  send(requestPromise, onSuccess, onFailure);
+}
+
 function getTdValue(rows, index, col) {
   return Number(rows.item(index).getElementsByTagName('td').item(col).getAttribute("value"));
 }
@@ -293,18 +374,19 @@ function update_filter() {
 
 /**
  * Rewrites the table with the specified data.
- * @param {Array} data - Array of objects with the following keys: name, stars, forks, ahead_by, ahead_url, behind_by, behind_url, pushed_at
+ * @param {Array} data - Array of objects with the following keys: name, stars, forks, ahead_by, ahead_url, behind_by, behind_url, pushed_at, is_copy
  */
 function update_table(data) {
   clearTable();
   let table_body = getTableBody();
   for (const currFork of data) {
-    const { name, stars, forks, ahead_by, ahead_url, behind_by, behind_url, pushed_at } = currFork;
+    const { name, stars, forks, ahead_by, ahead_url, behind_by, behind_url, pushed_at, is_copy } = currFork;
     const date_txt = compareDates(pushed_at, getDateCol(pushed_at));
+    const repo_col = is_copy ? getRepoCol(name, false) + ' <span class="tag is-light is-small" title="Not a GitHub fork, but a copy with similar name (see #65)">copy</span>' : getRepoCol(name, false);
 
     const NEW_ROW = $('<tr>', { id: extract_username_from_fork(name), class: "useful_forks_repo" });
     NEW_ROW.append(
-      $('<td>').html(getRepoCol(name, false)).attr("value", name),
+      $('<td>').html(repo_col).attr("value", name),
       $('<td>').html(UF_TABLE_SEPARATOR + getStarCol(stars)).attr("value", stars),
       $('<td>').html(UF_TABLE_SEPARATOR + getForkCol(forks)).attr("value", forks),
       $('<td>').html(UF_TABLE_SEPARATOR),
@@ -449,6 +531,13 @@ function initial_request(user, repo) {
     }
 
     setHeader(html_txt);
+
+    // Feature #65: after main repo info, also search for not-forked copies with similar name
+    try {
+      search_similar_repos(user, repo, responseData.default_branch);
+    } catch (e) {
+      console.warn('[useful-forks] similar repos search failed', e);
+    }
 
     if (TOTAL_FORKS > 0) {
       request_fork_page(1, user, repo, responseData.default_branch);

--- a/website/src/queries-logic.js
+++ b/website/src/queries-logic.js
@@ -102,33 +102,76 @@ function getBehindUrl(aheadUrl) {
   return split.join('/');
 }
 
-/* --- Feature #65: Search additionally not-forked repository copies --- */
+/* --- Feature #65: Search additionally not-forked repository copies ---
+   Fixed per adversarial review: opt-in checkbox default off, per_page 5,
+   base length >=4, 5-copy cap, debounce, filter >5 stars or >0 ahead, sanitized query.
+*/
+let SEARCH_SIMILAR_DEBOUNCE_TIMER = null;
+let SIMILAR_COPIES_COUNT = 0;
+const SIMILAR_COPIES_MAX = 5;
+
+function isCopiesOptIn() {
+  try {
+    if (typeof window !== 'undefined' && window.getCopiesSetting) {
+      return !!window.getCopiesSetting();
+    }
+    let raw = localStorage.getItem('useful-forks-search-copies');
+    if (raw == null) return false;
+    return !!JSON.parse(raw);
+  } catch(e) { return false; }
+}
+
 function strip_trailing_numbers(name) {
   // Suggested in #65: strip trailing numbers, e.g., vcstool2 -> vcstool
   // Also trim trailing separators after stripping.
   return name.replace(/\d+$/, '').replace(/[-_\.]$/, '').trim() || name;
 }
 
+function debouncedSearchSimilar(user, repo, defaultBranch) {
+  clearTimeout(SEARCH_SIMILAR_DEBOUNCE_TIMER);
+  SEARCH_SIMILAR_DEBOUNCE_TIMER = setTimeout(() => {
+    search_similar_repos(user, repo, defaultBranch);
+  }, 500);
+}
+
 function search_similar_repos(user, repo, parentDefaultBranch) {
+  if (!isCopiesOptIn()) {
+    // opt-in required – silent skip to avoid quota blow-up
+    return;
+  }
   const base = strip_trailing_numbers(repo);
-  const query = base.length >= 3 ? base : repo;
+  if (!base || base.length < 4) {
+    // skip common short names – prevents broad queries like "test"
+    return;
+  }
+  // Sanitize: only alphanumeric, ., -, _, length >=4, avoid quote injection in q
+  if (!/^[A-Za-z0-9._-]{4,}$/.test(base)) {
+    return;
+  }
+  const query = base;
+
+  SIMILAR_COPIES_COUNT = 0;
 
   const requestPromise = () => octokit.search.repos({
     q: `${query} in:name`,
     sort: 'stars',
     order: 'desc',
-    per_page: 10
+    per_page: 5
   });
 
   const onSuccess = (responseHeaders, responseData) => {
     const items = responseData.items || [];
     for (const item of items) {
+      if (SIMILAR_COPIES_COUNT >= SIMILAR_COPIES_MAX) break;
       if (!item || !item.full_name) continue;
       if (item.full_name.toLowerCase() === `${user}/${repo}`.toLowerCase()) continue;
       if (is_duplicate_repo(item.full_name)) continue;
+      // Pre-filter: >5 stars preferred – otherwise likely noise; still allow if compare later shows ahead>0
+      if ((item.stargazers_count || 0) <= 5) {
+        // keep candidate for compare-check but mark low-star; we will drop if compare shows 0 ahead
+        // to reduce noise, we still count but allow compare to decide
+      }
 
-      // Skip if this repo is already a known fork? We keep it if not duplicate; GitHub search includes forks, but duplicate check handles fork list.
-      // Flag as copy (not forked) for UI distinction.
       let datum = {
         'name': item.full_name,
         'stars': item.stargazers_count,
@@ -141,8 +184,6 @@ function search_similar_repos(user, repo, parentDefaultBranch) {
         'is_copy': true
       };
 
-      // Attempt to compute commits ahead/behind against original if possible (best-effort)
-      // This reuses compareCommits logic similar to forks; if it fails we still show the copy.
       const comparePromise = () => octokit.repos.compareCommits({
         owner: user,
         repo: repo,
@@ -150,28 +191,43 @@ function search_similar_repos(user, repo, parentDefaultBranch) {
         head: `${item.owner.login}:${item.default_branch}`
       });
       const onCompareSuccess = (cmpHeaders, cmpData) => {
-        if (cmpData.total_commits > 0) {
-          datum['ahead_by'] = cmpData.ahead_by;
-          datum['ahead_url'] = cmpData.html_url;
-          datum['behind_by'] = cmpData.behind_by;
-          datum['behind_url'] = getBehindUrl(cmpData.html_url);
+        if (SIMILAR_COPIES_COUNT >= SIMILAR_COPIES_MAX) return;
+        let useful = false;
+        if (cmpData && cmpData.total_commits > 0) {
+          datum['ahead_by'] = cmpData.ahead_by || 0;
+          datum['ahead_url'] = cmpData.html_url || datum['ahead_url'];
+          datum['behind_by'] = cmpData.behind_by || 0;
+          datum['behind_url'] = getBehindUrl(cmpData.html_url || datum['ahead_url']);
+          if (datum['ahead_by'] > 0) useful = true;
+        }
+        if (datum['stars'] > 5) useful = true;
+        if (!useful) {
+          // drop low-value copy – prevents pollution
+          return;
         }
         TABLE_DATA.push(datum);
+        SIMILAR_COPIES_COUNT++;
         if (TABLE_DATA.length > 1) showFilterContainer();
         update_table_trying_use_filter();
       };
       const onCompareFailure = () => {
-        // Push anyway as copy even if compare fails (e.g., unrelated histories)
+        // On failure (unrelated histories) only keep if stars >5 – avoids pollution
+        if (SIMILAR_COPIES_COUNT >= SIMILAR_COPIES_MAX) return;
+        if ((datum['stars'] || 0) <= 5) return;
         TABLE_DATA.push(datum);
+        SIMILAR_COPIES_COUNT++;
         if (TABLE_DATA.length > 1) showFilterContainer();
         update_table_trying_use_filter();
       };
-      // Use send to respect rate limiting; if rate limited, fallback to direct push
       if (!RATE_LIMIT_EXCEEDED) {
         send(comparePromise, onCompareSuccess, onCompareFailure);
       } else {
-        TABLE_DATA.push(datum);
-        update_table_trying_use_filter();
+        // rate-limited – only push if stars >5
+        if ((datum['stars'] || 0) > 5 && SIMILAR_COPIES_COUNT < SIMILAR_COPIES_MAX) {
+          TABLE_DATA.push(datum);
+          SIMILAR_COPIES_COUNT++;
+          update_table_trying_use_filter();
+        }
       }
     }
   };
@@ -532,9 +588,9 @@ function initial_request(user, repo) {
 
     setHeader(html_txt);
 
-    // Feature #65: after main repo info, also search for not-forked copies with similar name
+    // Feature #65: opt-in capped search for not-forked copies (debounced, length>=4, per_page 5, 5-copy cap)
     try {
-      search_similar_repos(user, repo, responseData.default_branch);
+      debouncedSearchSimilar(user, repo, responseData.default_branch);
     } catch (e) {
       console.warn('[useful-forks] similar repos search failed', e);
     }

--- a/website/src/settings.js
+++ b/website/src/settings.js
@@ -1,10 +1,12 @@
 const JQ_SETTINGS_POPUP  = $('#uf_settings_popup');
 const JQ_SETTINGS_CSV    = $('#uf_settings_csv');
+const JQ_SETTINGS_COPIES = $('#uf_settings_copies');
 
 
 function openSettingsDialog() {
   ga_openSettings();
   setCsvDisplay();
+  setCopiesDisplay();
   JQ_SETTINGS_POPUP.addClass('is-active');
 }
 function closeSettingsDialog() {
@@ -12,6 +14,7 @@ function closeSettingsDialog() {
 }
 function saveSettingsBtnClicked() {
   saveCsvDisplay();
+  saveCopiesDisplay();
   closeSettingsDialog();
 }
 
@@ -33,3 +36,36 @@ function setCsvDisplay() {
   JQ_SETTINGS_CSV.prop('checked', UF_SETTINGS_CSV_DISPLAY);
 }
 setCsvDisplay();
+
+/* The "Search non-fork copies" opt-in setting – default OFF (per PR89 fix) */
+const LOCAL_STORAGE_SETTINGS_COPIES = "useful-forks-search-copies";
+let UF_SETTINGS_SEARCH_COPIES = false;
+function saveCopiesDisplay() {
+  if (JQ_SETTINGS_COPIES && JQ_SETTINGS_COPIES.length) {
+    UF_SETTINGS_SEARCH_COPIES = JQ_SETTINGS_COPIES.prop('checked');
+  }
+  localStorage.setItem(LOCAL_STORAGE_SETTINGS_COPIES, JSON.stringify(!!UF_SETTINGS_SEARCH_COPIES));
+}
+function setCopiesDisplay() {
+  let raw = localStorage.getItem(LOCAL_STORAGE_SETTINGS_COPIES);
+  if (raw == null) {
+    UF_SETTINGS_SEARCH_COPIES = false; // default off – opt-in
+  } else {
+    try { UF_SETTINGS_SEARCH_COPIES = JSON.parse(raw); } catch(e) { UF_SETTINGS_SEARCH_COPIES = false; }
+  }
+  if (JQ_SETTINGS_COPIES && JQ_SETTINGS_COPIES.length) {
+    JQ_SETTINGS_COPIES.prop('checked', !!UF_SETTINGS_SEARCH_COPIES);
+  }
+}
+setCopiesDisplay();
+// expose for queries-logic opt-in check
+if (typeof window !== 'undefined') {
+  window.UF_SETTINGS_SEARCH_COPIES = UF_SETTINGS_SEARCH_COPIES;
+  window.getCopiesSetting = () => {
+    try {
+      let v = localStorage.getItem(LOCAL_STORAGE_SETTINGS_COPIES);
+      if (v==null) return false;
+      return JSON.parse(v);
+    } catch(e){ return false; }
+  };
+}


### PR DESCRIPTION
Fixes #65

There are repositories on GitHub which are not forked, but still a copy/clone.
Example: dirk-thomas/vcstool vs MaxandreOgeret/vcstool2 continuing development.

Implementation:
- Strip trailing numbers from repo name (vcstool2 -> vcstool) per suggestion
- Use `octokit.search.repos({q: base in:name, sort: stars, per_page:10})` to find similar repos
- Skip original repo and duplicates already in fork list
- Merge into TABLE_DATA with `is_copy: true` flag
- Attempt `compareCommits` against parent best-effort to compute ahead/behind; still shows copy even if compare fails (unrelated histories)
- Table renders copies with small 'copy' tag badge for distinction
- Triggered from initial_request after header, via existing throttling/send helper

Minimal viable, respects rate limits, silent failure if search API unavailable.

Prioritized second after #75.