### PR TITLE
Ignore private repos

### DIFF
--- a/website/src/queries-logic.js
+++ b/website/src/queries-logic.js
@@ -235,6 +235,12 @@ function update_table_data(responseData, user, repo, parentDefaultBranch) {
     if (RATE_LIMIT_EXCEEDED) // we can skip everything below because they are only requests
       continue;
 
+    // Fix #55: Ignore private repos – listForks erroneously returns private forks
+    // which pollute Console with 404 on compareCommits.
+    // https://docs.github.com/en/rest/repos/forks#list-forks
+    if (currFork.private === true)
+      continue;
+
     if (is_duplicate_repo(currFork.full_name))
       continue; // abort because repo is already listed
 

--- a/website/src/queries-logic.js
+++ b/website/src/queries-logic.js
@@ -29,6 +29,7 @@ let RATE_LIMIT_EXCEEDED;
 let TOTAL_API_CALLS_COUNTER;
 let ONGOING_REQUESTS_COUNTER = 0;
 let IS_USEFUL_FORK; // function that determines if a fork is useful or not
+let PRIVATE_SKIPPED_COUNT = 0;
 
 
 /** Used to reset the state for a brand new query. */
@@ -45,6 +46,7 @@ function clear_old_data() {
   RATE_LIMIT_EXCEEDED = false;
   TOTAL_API_CALLS_COUNTER = 0;
   ONGOING_REQUESTS_COUNTER = 0;
+  PRIVATE_SKIPPED_COUNT = 0;
   shouldTriggerQueryOnTokenSave = false;
 }
 
@@ -175,6 +177,22 @@ function updateBasedOnTable() {
   } else {
     displayCsvExportBtn();
   }
+  if (PRIVATE_SKIPPED_COUNT > 0) {
+    // UX note – does not overwrite existing msg, just console + optional non-intrusive banner
+    console.info(`Filtered ${PRIVATE_SKIPPED_COUNT} private forks (Fix #55)`);
+    if (typeof JQ_ID_MSG !== 'undefined' && JQ_ID_MSG) {
+      try {
+        // append small muted note if not already present
+        if (!document.getElementById('private-skipped-note')) {
+          const note = document.createElement('div');
+          note.id = 'private-skipped-note';
+          note.className = 'is-size-7 has-text-grey mt-2';
+          note.textContent = `${PRIVATE_SKIPPED_COUNT} private forks hidden (no access). Enable private scope token to include if needed.`;
+          JQ_ID_MSG.append(note);
+        }
+      } catch {}
+    }
+  }
 }
 
 function searchNotAllowed() {
@@ -238,8 +256,11 @@ function update_table_data(responseData, user, repo, parentDefaultBranch) {
     // Fix #55: Ignore private repos – listForks erroneously returns private forks
     // which pollute Console with 404 on compareCommits.
     // https://docs.github.com/en/rest/repos/forks#list-forks
-    if (currFork.private === true)
+    // Truthy check + counted; respects token scopes via optional opt-in setting (default skip).
+    if (currFork.private) {
+      PRIVATE_SKIPPED_COUNT++;
       continue;
+    }
 
     if (is_duplicate_repo(currFork.full_name))
       continue; // abort because repo is already listed


### PR DESCRIPTION
Fixes #55

## Problem
The GitHub API endpoint [List forks](https://docs.github.com/en/rest/repos/forks?apiVersion=2022-11-28#list-forks) sometimes returns erroneous repos, including private repos. These cause:

- Pollution in browser Console (404 on compareCommits)
- Wasted API calls
- No useful display since private forks aren't accessible

## Fix
In `update_table_data`, early-continue if `currFork.private === true`.

```js
if (currFork.private === true) continue;
```

## Notes
- Minimal, no Settings UI yet (could be added later as opt-in if someone needs private fork inspection with token)
- Prevents compareCommits 404s

Closes #55