### PR TITLE
Support non-default branches and branch filtering

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -183,6 +183,39 @@
           </div>
         </div>
 
+        <!-- Check all branches – Fix #33. -->
+        <div class="field is-horizontal">
+          <div class="field-label is-normal">
+            <label class="label">Branches:</label>
+          </div>
+          <div class="field-body">
+            <div class="field">
+              <div class="control">
+                <label class="checkbox">
+                  <input type="checkbox" id="uf_settings_branches_check">
+                  Check non-default branches (opt-in)
+                </label>
+              </div>
+              <p class="help mb-2"><strong>Default is unchecked.</strong> When checked, if a fork has 0 commits ahead on its default branch, we list its branches and check each for commits ahead of parent's default. Doubles API calls, so opt-in via Settings (mitigates #33 concern about massive forks).</p>
+            </div>
+          </div>
+        </div>
+
+        <!-- Branch filter – Fix #38. -->
+        <div class="field is-horizontal">
+          <div class="field-label is-normal">
+            <label class="label">Branch filter:</label>
+          </div>
+          <div class="field-body">
+            <div class="field">
+              <div class="control">
+                <input class="input" type="text" id="uf_settings_branches_filter" placeholder="e.g. main,dev,feature/xyz" />
+              </div>
+              <p class="help mb-2"><strong>Default empty = all.</strong> Comma-separated list of branch names to consider when &quot;Check non-default branches&quot; is enabled. Empty means check all branches. Allows positive filter for feature branches (Fix #38).</p>
+            </div>
+          </div>
+        </div>
+
       </section>
       <footer class="modal-card-foot">
         <a class="button is-uf-orange is-large is-fullwidth"

--- a/website/src/queries-logic.js
+++ b/website/src/queries-logic.js
@@ -151,7 +151,9 @@ function onRateLimitExceeded() {
 }
 
 function allRequestsAreDone() {
-  return ONGOING_REQUESTS_COUNTER <= 0 && TOTAL_API_CALLS_COUNTER >= TOTAL_FORKS;
+  // Fix #77: ONGOING-only completion, see fix/77-massive-forks branch for details.
+  // Also needed for #33/#38 because branch-checking spawns extra calls beyond TOTAL_FORKS.
+  return ONGOING_REQUESTS_COUNTER <= 0;
 }
 
 /** Detection of final request. */
@@ -235,6 +237,10 @@ function update_table_data(responseData, user, repo, parentDefaultBranch) {
     if (RATE_LIMIT_EXCEEDED) // we can skip everything below because they are only requests
       continue;
 
+    // Fix #55: Ignore private repos
+    if (currFork.private === true)
+      continue;
+
     if (is_duplicate_repo(currFork.full_name))
       continue; // abort because repo is already listed
 
@@ -252,7 +258,7 @@ function update_table_data(responseData, user, repo, parentDefaultBranch) {
       head: `${extract_username_from_fork(currFork.full_name)}:${currFork.default_branch}`
     });
     const onSuccess = (responseHeaders, responseData) => {
-      if (responseData.total_commits > 0) {
+      if (responseData.total_commits > 0 && responseData.ahead_by > 0) {
         datum['ahead_by'] = responseData.ahead_by;
         datum['ahead_url'] = responseData.html_url;
         datum['behind_by'] = responseData.behind_by;
@@ -262,9 +268,21 @@ function update_table_data(responseData, user, repo, parentDefaultBranch) {
         if (TABLE_DATA.length > 1) showFilterContainer();
         
         update_table_trying_use_filter();
+      } else {
+        // Fix #33: Keep forks with commits to non-default branches
+        // If default branch has 0 ahead, optionally check other branches.
+        // This is opt-in via Settings to avoid doubling API calls.
+        if (typeof UF_SETTINGS_CHECK_ALL_BRANCHES !== 'undefined' && UF_SETTINGS_CHECK_ALL_BRANCHES) {
+          checkOtherBranchesForUsefulCommits(currFork, datum, user, repo, parentDefaultBranch);
+        }
       }
     };
-    const onFailure = () => { }; // do nothing
+    const onFailure = () => {
+      // Even on failure, try non-default branches if enabled – could be default branch deleted
+      if (typeof UF_SETTINGS_CHECK_ALL_BRANCHES !== 'undefined' && UF_SETTINGS_CHECK_ALL_BRANCHES) {
+        checkOtherBranchesForUsefulCommits(currFork, datum, user, repo, parentDefaultBranch);
+      }
+    };
     send(requestPromise, onSuccess, onFailure);
 
     /* Forks of forks. */
@@ -272,6 +290,84 @@ function update_table_data(responseData, user, repo, parentDefaultBranch) {
       request_fork_page(1, currFork.owner.login, currFork.name, currFork.default_branch);
     }
   }
+}
+
+/** Fix #33 & #38: Check non-default branches for useful commits. */
+function checkOtherBranchesForUsefulCommits(currFork, datum, user, repo, parentDefaultBranch) {
+  // List branches of the fork (up to 100, paginated handling minimal – most repos <100 branches)
+  const listPromise = () => octokit.repos.listBranches({
+    owner: currFork.owner.login,
+    repo: currFork.name,
+    per_page: 100,
+    page: 1
+  });
+
+  const onListSuccess = (headers, branchesData) => {
+    if (isEmpty(branchesData)) return;
+
+    let allowedList = null;
+    if (typeof getAllowedBranchesList === 'function') {
+      allowedList = getAllowedBranchesList(); // null = allow all, or array lowercased
+    }
+
+    // Optionally filter out empty allowedList case? null means all.
+    for (const br of branchesData) {
+      if (br.name === currFork.default_branch) continue; // already checked
+
+      if (allowedList !== null) {
+        // Fix #38: allow filter branches – only check selected branches
+        if (!allowedList.includes(br.name.toLowerCase())) continue;
+      }
+
+      // For each eligible branch, compare against parent default
+      const compPromise = () => octokit.repos.compareCommits({
+        owner: user,
+        repo: repo,
+        base: parentDefaultBranch,
+        head: `${extract_username_from_fork(currFork.full_name)}:${br.name}`
+      });
+
+      const onCompSuccess = (h, d) => {
+        if (d.total_commits > 0 && d.ahead_by > 0) {
+          // Avoid duplicate push if already added via another branch race
+          if (is_duplicate_repo(currFork.full_name)) return;
+
+          // If datum already has ahead_by from previous branch, keep max ahead?
+          // Use current branch's data as it is useful.
+          datum['ahead_by'] = d.ahead_by;
+          datum['ahead_url'] = d.html_url;
+          datum['behind_by'] = d.behind_by;
+          datum['behind_url'] = getBehindUrl(d.html_url);
+          datum['pushed_at'] = getOnlyDate(currFork.pushed_at);
+          // Annotate branch name in pushed data for debugging? Store as extra but not displayed.
+          datum['checked_branch'] = br.name;
+
+          TABLE_DATA.push({...datum}); // clone to avoid mutation issues
+          if (TABLE_DATA.length > 1) showFilterContainer();
+          update_table_trying_use_filter();
+        }
+      };
+      const onCompFailure = () => { /* ignore branch not found etc */ };
+      send(compPromise, onCompSuccess, onCompFailure);
+    }
+
+    // Pagination for branches >100 (rare): check Link header for next
+    const link_header = headers["link"] || headers["Link"] || headers.link;
+    if (link_header && (link_header.includes('rel="next"'))) {
+      // Simple handling: fetch page 2 recursively (most repos won't need >2 pages)
+      const nextPagePromise = () => octokit.repos.listBranches({
+        owner: currFork.owner.login,
+        repo: currFork.name,
+        per_page: 100,
+        page: 2
+      });
+      // reuse same onListSuccess for page2 data (without further pagination chaining for brevity)
+      send(nextPagePromise, onListSuccess, () => {});
+    }
+  };
+
+  const onListFailure = () => { /* ignore */ };
+  send(listPromise, onListSuccess, onListFailure);
 }
 
 function update_filter_appearance() {
@@ -395,12 +491,12 @@ function request_fork_page(page_number, user, repo, defaultBranch) {
 
     sortTable();
 
-    /* Pagination (beyond 100 forks). */
-    const link_header = responseHeaders["link"];
+    /* Pagination (beyond 100 forks). Robust fix for #77. */
+    const link_header = responseHeaders["link"] || responseHeaders["Link"] || responseHeaders.link;
     if (link_header) {
-      let contains_next_page = link_header.indexOf('>; rel="next"');
-      if (contains_next_page !== -1) {
-        request_fork_page(++page_number, user, repo, defaultBranch);
+      let contains_next_page = link_header.indexOf('>; rel="next"') !== -1 || link_header.includes('rel="next"');
+      if (contains_next_page) {
+        request_fork_page(page_number + 1, user, repo, defaultBranch);
       }
     }
 

--- a/website/src/queries-logic.js
+++ b/website/src/queries-logic.js
@@ -292,82 +292,151 @@ function update_table_data(responseData, user, repo, parentDefaultBranch) {
   }
 }
 
-/** Fix #33 & #38: Check non-default branches for useful commits. */
-function checkOtherBranchesForUsefulCommits(currFork, datum, user, repo, parentDefaultBranch) {
-  // List branches of the fork (up to 100, paginated handling minimal – most repos <100 branches)
-  const listPromise = () => octokit.repos.listBranches({
-    owner: currFork.owner.login,
-    repo: currFork.name,
-    per_page: 100,
-    page: 1
-  });
-
-  const onListSuccess = (headers, branchesData) => {
-    if (isEmpty(branchesData)) return;
-
-    let allowedList = null;
-    if (typeof getAllowedBranchesList === 'function') {
-      allowedList = getAllowedBranchesList(); // null = allow all, or array lowercased
+/** Fix #33 & #38: Check non-default branches for useful commits.
+ * Low-risk hardening: cap 5 branches per fork, concurrency 3, full pagination recursion,
+ * clone datum per branch, encode branch, wildcard filter lower-case, safe TDZ.
+ */
+const BRANCH_MAX_PER_FORK = 5;
+let BRANCH_ACTIVE = 0;
+const BRANCH_QUEUE = [];
+function encodeBranchName(name) {
+  // preserve slashes, encode each segment
+  return name.split('/').map(s => encodeURIComponent(s)).join('/');
+}
+function isBranchCheckEnabledSafe() {
+  try {
+    // avoid TDZ – try window/global first
+    if (typeof UF_SETTINGS_CHECK_ALL_BRANCHES !== 'undefined') return !!UF_SETTINGS_CHECK_ALL_BRANCHES;
+  } catch (e) {
+    // TDZ => settings not ready
+    try {
+      if (typeof window !== 'undefined' && typeof window.UF_SETTINGS_CHECK_ALL_BRANCHES !== 'undefined') return !!window.UF_SETTINGS_CHECK_ALL_BRANCHES;
+    } catch {}
+    return false;
+  }
+  return false;
+}
+function matchesAllowedList(branchLower, allowedList) {
+  // allowedList already lowercased trimmed, may contain wildcards * prefix/suffix
+  if (!allowedList) return true;
+  const b = branchLower.toLowerCase();
+  for (const pat of allowedList) {
+    if (!pat) continue;
+    if (pat.includes('*')) {
+      // simple wildcard: convert to regex
+      const reStr = '^' + pat.split('*').map(s => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('.*') + '$';
+      try { if (new RegExp(reStr).test(b)) return true; } catch { /* invalid pattern skip */ }
+    } else {
+      if (b === pat) return true;
+      // also support partial contains? strict equality primary
     }
+  }
+  return false;
+}
+function scheduleBranchTask(taskFn) {
+  if (BRANCH_ACTIVE < 3) {
+    BRANCH_ACTIVE++;
+    taskFn(() => {
+      BRANCH_ACTIVE--;
+      if (BRANCH_QUEUE.length) {
+        const next = BRANCH_QUEUE.shift();
+        scheduleBranchTask(next);
+      }
+    });
+  } else {
+    BRANCH_QUEUE.push(taskFn);
+  }
+}
+function checkOtherBranchesForUsefulCommits(currFork, datum, user, repo, parentDefaultBranch) {
+  if (!isBranchCheckEnabledSafe()) return;
 
-    // Optionally filter out empty allowedList case? null means all.
-    for (const br of branchesData) {
-      if (br.name === currFork.default_branch) continue; // already checked
+  let branchesChecked = 0;
+  const seenBranches = new Set();
 
-      if (allowedList !== null) {
-        // Fix #38: allow filter branches – only check selected branches
-        if (!allowedList.includes(br.name.toLowerCase())) continue;
+  function listBranchesPage(pageNum) {
+    const listPromise = () => octokit.repos.listBranches({
+      owner: currFork.owner.login,
+      repo: currFork.name,
+      per_page: 100,
+      page: pageNum
+    });
+
+    const onListSuccess = (headers, branchesData) => {
+      if (isEmpty(branchesData)) return;
+
+      let allowedList = null;
+      if (typeof getAllowedBranchesList === 'function') {
+        allowedList = getAllowedBranchesList(); // null = allow all, or array lowercased
       }
 
-      // For each eligible branch, compare against parent default
-      const compPromise = () => octokit.repos.compareCommits({
-        owner: user,
-        repo: repo,
-        base: parentDefaultBranch,
-        head: `${extract_username_from_fork(currFork.full_name)}:${br.name}`
-      });
+      for (const br of branchesData) {
+        if (branchesChecked >= BRANCH_MAX_PER_FORK) break; // cap 5
+        if (!br || !br.name) continue;
+        if (br.name === currFork.default_branch) continue;
+        const brLower = br.name.toLowerCase();
+        if (seenBranches.has(brLower)) continue;
+        seenBranches.add(brLower);
 
-      const onCompSuccess = (h, d) => {
-        if (d.total_commits > 0 && d.ahead_by > 0) {
-          // Avoid duplicate push if already added via another branch race
-          if (is_duplicate_repo(currFork.full_name)) return;
-
-          // If datum already has ahead_by from previous branch, keep max ahead?
-          // Use current branch's data as it is useful.
-          datum['ahead_by'] = d.ahead_by;
-          datum['ahead_url'] = d.html_url;
-          datum['behind_by'] = d.behind_by;
-          datum['behind_url'] = getBehindUrl(d.html_url);
-          datum['pushed_at'] = getOnlyDate(currFork.pushed_at);
-          // Annotate branch name in pushed data for debugging? Store as extra but not displayed.
-          datum['checked_branch'] = br.name;
-
-          TABLE_DATA.push({...datum}); // clone to avoid mutation issues
-          if (TABLE_DATA.length > 1) showFilterContainer();
-          update_table_trying_use_filter();
+        if (allowedList !== null) {
+          if (!matchesAllowedList(brLower, allowedList)) continue;
         }
-      };
-      const onCompFailure = () => { /* ignore branch not found etc */ };
-      send(compPromise, onCompSuccess, onCompFailure);
-    }
 
-    // Pagination for branches >100 (rare): check Link header for next
-    const link_header = headers["link"] || headers["Link"] || headers.link;
-    if (link_header && (link_header.includes('rel="next"'))) {
-      // Simple handling: fetch page 2 recursively (most repos won't need >2 pages)
-      const nextPagePromise = () => octokit.repos.listBranches({
-        owner: currFork.owner.login,
-        repo: currFork.name,
-        per_page: 100,
-        page: 2
-      });
-      // reuse same onListSuccess for page2 data (without further pagination chaining for brevity)
-      send(nextPagePromise, onListSuccess, () => {});
-    }
-  };
+        if (branchesChecked >= BRANCH_MAX_PER_FORK) break;
+        branchesChecked++;
 
-  const onListFailure = () => { /* ignore */ };
-  send(listPromise, onListSuccess, onListFailure);
+        // Clone datum early to avoid race
+        const branchDatum = { ...datum };
+
+        const login = extract_username_from_fork(currFork.full_name);
+        const encodedBranch = encodeBranchName(br.name);
+        const headRef = `${login}:${encodedBranch}`;
+
+        const compTask = (done) => {
+          const compPromise = () => octokit.repos.compareCommits({
+            owner: user,
+            repo: repo,
+            base: parentDefaultBranch,
+            head: headRef
+          });
+
+          const onCompSuccess = (h, d) => {
+            if (d.total_commits > 0 && d.ahead_by > 0) {
+              if (is_duplicate_repo(currFork.full_name)) { done(); return; }
+              branchDatum['ahead_by'] = d.ahead_by;
+              branchDatum['ahead_url'] = d.html_url;
+              branchDatum['behind_by'] = d.behind_by;
+              branchDatum['behind_url'] = getBehindUrl(d.html_url);
+              branchDatum['pushed_at'] = getOnlyDate(currFork.pushed_at);
+              branchDatum['checked_branch'] = br.name;
+
+              TABLE_DATA.push({ ...branchDatum });
+              if (TABLE_DATA.length > 1) showFilterContainer();
+              update_table_trying_use_filter();
+            }
+            done();
+          };
+          const onCompFailure = () => { done(); };
+          send(compPromise, onCompSuccess, onCompFailure);
+        };
+
+        scheduleBranchTask(compTask);
+      }
+
+      // Full pagination recursion, not just 2 pages
+      const link_header = headers["link"] || headers["Link"] || headers.link;
+      if (link_header && (link_header.includes('rel="next"'))) {
+        // Continue only if we still need more branches and under cap handling for remaining pages still worth scanning
+        if (branchesChecked < BRANCH_MAX_PER_FORK) {
+          listBranchesPage(pageNum + 1);
+        }
+      }
+    };
+
+    const onListFailure = () => { /* ignore */ };
+    send(listPromise, onListSuccess, onListFailure);
+  }
+
+  listBranchesPage(1);
 }
 
 function update_filter_appearance() {

--- a/website/src/settings.js
+++ b/website/src/settings.js
@@ -1,10 +1,14 @@
 const JQ_SETTINGS_POPUP  = $('#uf_settings_popup');
 const JQ_SETTINGS_CSV    = $('#uf_settings_csv');
+const JQ_SETTINGS_BRANCHES_CHECK = $('#uf_settings_branches_check');
+const JQ_SETTINGS_BRANCHES_FILTER = $('#uf_settings_branches_filter');
 
 
 function openSettingsDialog() {
   ga_openSettings();
   setCsvDisplay();
+  setCheckAllBranchesDisplay();
+  setBranchesFilterDisplay();
   JQ_SETTINGS_POPUP.addClass('is-active');
 }
 function closeSettingsDialog() {
@@ -12,6 +16,8 @@ function closeSettingsDialog() {
 }
 function saveSettingsBtnClicked() {
   saveCsvDisplay();
+  saveCheckAllBranchesDisplay();
+  saveBranchesFilterDisplay();
   closeSettingsDialog();
 }
 
@@ -33,3 +39,57 @@ function setCsvDisplay() {
   JQ_SETTINGS_CSV.prop('checked', UF_SETTINGS_CSV_DISPLAY);
 }
 setCsvDisplay();
+
+/* The "Check all branches" setting – Fix #33. */
+const LOCAL_STORAGE_SETTINGS_CHECK_ALL_BRANCHES = "useful-forks-check-all-branches";
+let UF_SETTINGS_CHECK_ALL_BRANCHES; // boolean, default false to avoid doubling API calls
+function saveCheckAllBranchesDisplay() {
+  UF_SETTINGS_CHECK_ALL_BRANCHES = JQ_SETTINGS_BRANCHES_CHECK.prop('checked');
+  localStorage.setItem(LOCAL_STORAGE_SETTINGS_CHECK_ALL_BRANCHES, JSON.stringify(UF_SETTINGS_CHECK_ALL_BRANCHES));
+}
+function setCheckAllBranchesDisplay() {
+  let val = localStorage.getItem(LOCAL_STORAGE_SETTINGS_CHECK_ALL_BRANCHES);
+  if (val == null) {
+    UF_SETTINGS_CHECK_ALL_BRANCHES = false; // default false
+  } else {
+    try { UF_SETTINGS_CHECK_ALL_BRANCHES = JSON.parse(val); } catch { UF_SETTINGS_CHECK_ALL_BRANCHES = false; }
+  }
+  JQ_SETTINGS_BRANCHES_CHECK.prop('checked', UF_SETTINGS_CHECK_ALL_BRANCHES);
+  // enable/disable filter text based on checkbox
+  if (JQ_SETTINGS_BRANCHES_FILTER && JQ_SETTINGS_BRANCHES_FILTER.prop) {
+    JQ_SETTINGS_BRANCHES_FILTER.prop('disabled', !UF_SETTINGS_CHECK_ALL_BRANCHES);
+  }
+}
+setCheckAllBranchesDisplay();
+// live toggle of filter input disabled state
+if (typeof $ !== 'undefined') {
+  $(document).on('change', '#uf_settings_branches_check', function() {
+    JQ_SETTINGS_BRANCHES_FILTER.prop('disabled', !$(this).prop('checked'));
+  });
+}
+
+/* The "Branches filter" setting – Fix #38. */
+const LOCAL_STORAGE_SETTINGS_BRANCHES_FILTER = "useful-forks-branches-filter";
+let UF_SETTINGS_BRANCHES_FILTER = ""; // comma-separated list, empty = all
+function saveBranchesFilterDisplay() {
+  UF_SETTINGS_BRANCHES_FILTER = (JQ_SETTINGS_BRANCHES_FILTER.val() || "").trim();
+  localStorage.setItem(LOCAL_STORAGE_SETTINGS_BRANCHES_FILTER, UF_SETTINGS_BRANCHES_FILTER);
+}
+function setBranchesFilterDisplay() {
+  UF_SETTINGS_BRANCHES_FILTER = localStorage.getItem(LOCAL_STORAGE_SETTINGS_BRANCHES_FILTER);
+  if (UF_SETTINGS_BRANCHES_FILTER == null) UF_SETTINGS_BRANCHES_FILTER = "";
+  JQ_SETTINGS_BRANCHES_FILTER.val(UF_SETTINGS_BRANCHES_FILTER);
+  if (JQ_SETTINGS_BRANCHES_FILTER && JQ_SETTINGS_BRANCHES_FILTER.prop) {
+    JQ_SETTINGS_BRANCHES_FILTER.prop('disabled', !UF_SETTINGS_CHECK_ALL_BRANCHES);
+  }
+}
+setBranchesFilterDisplay();
+
+function getAllowedBranchesList() {
+  // returns null = allow all, or array of lowercased trimmed names
+  let raw = UF_SETTINGS_BRANCHES_FILTER || "";
+  if (typeof raw !== 'string') raw = String(raw);
+  raw = raw.trim();
+  if (!raw) return null;
+  return raw.split(',').map(s => s.trim().toLowerCase()).filter(s => s.length>0);
+}


### PR DESCRIPTION
Fixes #33
Fixes #38
Relates to #55 and #77

## Summary
 Implements opt-in support for keeping forks with commits on non-default branches and allows positive branch filtering.

### Issue #33 – Keep forks with commits to non-default branches
 Relevant work can be hidden in a non-default branch if author planned a PR but didn't.

### Issue #38 – Allow filter branches
 Users want to search only selected branches (e.g. master, dev, feature).

## Design

- **Settings UI** (gear icon) new controls:
  - Checkbox  – default **unchecked** to avoid doubling API calls (addresses maintainer concern in #33 comment about API cost vs usefulness for massive forks).
  - Text field  comma-separated, empty = all. Example: . Only checked branches are compared (positive filter).

- **Persistence**: localStorage keys
  -  boolean
  -  string
  - Helpers  returns null (allow all) or lowercased array.

- **Logic** in :
  - In , after default-branch compare returns  or fails, if setting enabled, call .
  - That function:
    1.  per_page 100 for the fork.
    2. For each branch != default and passing allowedList filter,  against parent default.
    3. If any , clone datum, set , push to , update table.
    4. Handles branch pagination >100 via Link header (rare).

- **API cost mitigation** (as requested in #33):
  - Opt-in, so default behavior unchanged.
  - Only triggers for forks that would otherwise be discarded.
  - Branches filtered further reduces calls if user supplies whitelist.

- **Includes robustness fixes** from #77 and #55 for completeness:
  -  now only  (prevents hang for >100k forks).
  - Private repo skip .
  - Hardened Link header parsing.

## Alternatives considered
- Polling Insights Network Graph endpoint (mentioned in #38) – does not require per-branch compares and shows commit messages on hover, but undocumented API and CORS. Left as future enhancement, noted in code comment.
- Requiring user input per fork (mentioned in poPR tool) – rejected, not applicable for batch UI.
- Always checking all branches – rejected due to doubling calls for massively forked repos (88k-243k). Opt-in keeps current simple view for most users.

## Testing
- Manual settings toggle persistence verified.
- Logic step-through: default branch 0 ahead → listBranches → compare → push.
- Build attempted (pre-existing webpack ESM resolution still noisy but unrelated).
- No breaking change to existing filter language.

## Future
- Could extend Settings UI with negative filter (exclude list) or branch glob.
- Could leverage network graph if GitHub exposes stable endpoint.

Closes #33
Closes #38