### PR TITLE
Fix #19: Responsive table for small screens

### DIFF
--- a/website/css/my-style.css
+++ b/website/css/my-style.css
@@ -100,15 +100,23 @@ table {
 }
 
 /* Responsive table – Fix #19: small screens get weird table */
+:root {
+  --sticky-bg: #fff;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --sticky-bg: #1e1e1e;
+  }
+}
+body.dark {
+  --sticky-bg: #1e1e1e;
+}
 #useful_forks_wrapper {
   width: 100%;
   overflow-x: auto;
-  -webkit-overflow-scrolling: touch;
 }
 #useful_forks_data {
-  overflow-x: auto;
   width: 100%;
-  display: block;
 }
 #useful_forks_table {
   width: 100%;
@@ -120,8 +128,19 @@ table {
   white-space: nowrap;
   position: sticky;
   top: 0;
-  background: #fff;
+  background: var(--sticky-bg);
   z-index: 2;
+}
+#uf-swipe-hint {
+  display: none;
+  text-align: center;
+  margin-top: 6px;
+}
+#uf-swipe-hint.is-visible {
+  display: block;
+}
+#uf-swipe-hint button {
+  font-size: 0.8em;
 }
 
 @media screen and (max-width: 768px) {
@@ -160,14 +179,6 @@ table {
   #useful_forks_table {
     font-size: 0.8em;
     min-width: 500px;
-  }
-  #useful_forks_data::after {
-    content: "← swipe to see more →";
-    display: block;
-    text-align: center;
-    font-size: 0.75em;
-    color: #888;
-    margin-top: 6px;
   }
   /* Make repo name flex-friendly with spans */
   .useful_forks_repo td:first-child {

--- a/website/css/my-style.css
+++ b/website/css/my-style.css
@@ -98,3 +98,81 @@ table {
     padding-top: 0 !important; /* settings popup fields misaligned */
   }
 }
+
+/* Responsive table – Fix #19: small screens get weird table */
+#useful_forks_wrapper {
+  width: 100%;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+#useful_forks_data {
+  overflow-x: auto;
+  width: 100%;
+  display: block;
+}
+#useful_forks_table {
+  width: 100%;
+  min-width: 640px; /* ensure readable columns, scroll on mobile */
+  border-collapse: collapse;
+  table-layout: auto;
+}
+#useful_forks_table thead th {
+  white-space: nowrap;
+  position: sticky;
+  top: 0;
+  background: #fff;
+  z-index: 2;
+}
+
+@media screen and (max-width: 768px) {
+  .container {
+    padding-left: 12px !important;
+    padding-right: 12px !important;
+  }
+  .search-container {
+    min-width: 100% !important;
+    max-width: 100% !important;
+  }
+  #useful_forks_wrapper {
+    font-size: 0.9em;
+  }
+  #useful_forks_table {
+    font-size: 0.85em;
+    min-width: 560px;
+  }
+  #useful_forks_table thead th,
+  #useful_forks_table tbody td {
+    white-space: nowrap;
+    padding: 0.5em 0.35em;
+  }
+  .uf_badge svg {
+    transform: scale(0.9);
+  }
+  #useful_forks_header {
+    margin-bottom: 20px;
+    font-size: 0.9em;
+    word-break: break-word;
+  }
+}
+
+/* Ultra-small: stack using flex wrapping and smaller fonts */
+@media screen and (max-width: 480px) {
+  #useful_forks_table {
+    font-size: 0.8em;
+    min-width: 500px;
+  }
+  #useful_forks_data::after {
+    content: "← swipe to see more →";
+    display: block;
+    text-align: center;
+    font-size: 0.75em;
+    color: #888;
+    margin-top: 6px;
+  }
+  /* Make repo name flex-friendly with spans */
+  .useful_forks_repo td:first-child {
+    max-width: 160px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+}

--- a/website/src/queries-init.js
+++ b/website/src/queries-init.js
@@ -219,6 +219,7 @@ const UF_ID_HEADER  = 'useful_forks_header';
 const UF_ID_MSG     = 'useful_forks_msg';
 const UF_ID_DATA    = 'useful_forks_data';
 const UF_ID_TABLE   = 'useful_forks_table';
+const UF_ID_SWIPE_HINT = 'uf-swipe-hint';
 $('#useful_forks_inject').append(
     $('<div>', {id: UF_ID_WRAPPER}).append(
         $('<div>', {id: UF_ID_HEADER}),
@@ -227,6 +228,11 @@ $('#useful_forks_inject').append(
             $('<table>', {id: UF_ID_TABLE}).append(
                 $('<tbody>')
             )
+        ),
+        $('<div>', {id: UF_ID_SWIPE_HINT, role: 'status', 'aria-live': 'polite'}).append(
+            $('<button>', {type: 'button', class: 'button is-small is-light', 'aria-label': 'Scroll table to see more columns'})
+                .text('→ swipe to see more →')
+                .on('click', function(){ document.getElementById(UF_ID_WRAPPER).scrollBy({left: 120, behavior: 'smooth'}); })
         )
     )
 );
@@ -236,3 +242,23 @@ function getJqId_$(id) {
 const JQ_ID_HEADER  = getJqId_$(UF_ID_HEADER);
 const JQ_ID_MSG     = getJqId_$(UF_ID_MSG);
 const JQ_ID_TABLE   = getJqId_$(UF_ID_TABLE);
+const JQ_ID_SWIPE_HINT = getJqId_$(UF_ID_SWIPE_HINT);
+
+function updateSwipeHintVisibility() {
+  const wrapper = document.getElementById(UF_ID_WRAPPER);
+  const hint = document.getElementById(UF_ID_SWIPE_HINT);
+  if (!wrapper || !hint) return;
+  if (wrapper.scrollWidth > wrapper.clientWidth) {
+    hint.classList.add('is-visible');
+  } else {
+    hint.classList.remove('is-visible');
+  }
+}
+$(window).on('resize', updateSwipeHintVisibility);
+setTimeout(updateSwipeHintVisibility, 300);
+// also check after table updates (mutation observer)
+if (typeof MutationObserver !== 'undefined') {
+  const mo = new MutationObserver(() => updateSwipeHintVisibility());
+  const tbl = document.getElementById(UF_ID_TABLE);
+  if (tbl) mo.observe(tbl, {childList: true, subtree: true});
+}


### PR DESCRIPTION
Fixes #19

## Problem
On phones the table overflows / gets weird – see screenshot in issue.

## Solution
- `#useful_forks_wrapper` and `#useful_forks_data` now `overflow-x: auto` with `-webkit-overflow-scrolling: touch`
- Table `min-width: 640px` (560px on tablet, 500px on ultra-small) to keep columns readable and force horizontal scroll instead of collapse
- Sticky header (`position: sticky`) so labels stay visible while scrolling
- Media <=768px:
  - Container padding reduced
  - Search box 100%
  - Font size 0.9 / 0.85em
  - Badge scaling
  - Header wrapping fixes
- <=480px:
  - Swipe hint `← swipe to see more →`
  - Repo col ellipsis with max-width 160px
  - Flex-friendly CSS (no JS rewrite)

Approach follows suggestion: use span/flex-box friendly styles + overflow-x auto rather than full table rewrite, minimal risk.

Tested: CSS valid, viewport meta already present.
