### PR TITLE
Fix #60: Display export CSV button takes effect dynamically

### DIFF
--- a/website/src/csv-export.js
+++ b/website/src/csv-export.js
@@ -11,8 +11,13 @@ function displayCsvExportBtn() {
   if (!UF_SETTINGS_CSV_DISPLAY) {
     return;
   }
-  // avoid duplicate
+  // source-of-truth: TABLE_DATA length, not DOM
+  if (typeof TABLE_DATA !== 'undefined' && TABLE_DATA.length === 0) {
+    return;
+  }
+  // idempotent: if already present, just ensure handler is fresh
   if (getJqId_$(EXPORT_DIV_ID).length > 0) {
+    setClickEvent();
     return;
   }
   JQ_ID_HEADER.append(EXPORT_DIV);
@@ -20,32 +25,25 @@ function displayCsvExportBtn() {
 }
 function hideExportCsvBtn() {
   // Always attempt to remove regardless of setting – allows dynamic toggle #60
-  // Original guard prevented removal when setting disabled, leaving stale button.
   getJqId_$(EXPORT_DIV_ID).remove();
 }
 function forceHideCsvBtn() {
-  getJqId_$(EXPORT_DIV_ID).remove();
+  // deprecated alias – keep for compat, single source
+  hideExportCsvBtn();
 }
 function updateCsvBtnVisibility() {
-  // central helper for #60: respects setting and table emptiness
-  try {
-    const empty = (typeof tableIsEmpty === 'function' ? tableIsEmpty() : (getTableBody && getTableBody().children().length === 0));
-    if (UF_SETTINGS_CSV_DISPLAY && !empty) {
-      displayCsvExportBtn();
-    } else {
-      hideExportCsvBtn();
-    }
-  } catch(e) {
-    // fallback: just toggle based on setting alone
-    if (UF_SETTINGS_CSV_DISPLAY) {
-      displayCsvExportBtn();
-    } else {
-      hideExportCsvBtn();
-    }
+  // central helper for #60: respects setting and TABLE_DATA length source-of-truth
+  const hasData = (typeof TABLE_DATA !== 'undefined')
+    ? TABLE_DATA.length > 0
+    : (typeof getTableBody === 'function' && getTableBody().children().length > 0);
+  if (UF_SETTINGS_CSV_DISPLAY && hasData) {
+    displayCsvExportBtn();
+  } else {
+    hideExportCsvBtn();
   }
 }
 function setClickEvent() {
-  EXPORT_BTN.on('click', function (event) {
+  EXPORT_BTN.off('click').on('click', function (event) {
     downloadCsv.apply(this);
     const query = JQ_REPO_FIELD.val();
     ga_exportCSV(query);

--- a/website/src/csv-export.js
+++ b/website/src/csv-export.js
@@ -11,14 +11,38 @@ function displayCsvExportBtn() {
   if (!UF_SETTINGS_CSV_DISPLAY) {
     return;
   }
+  // avoid duplicate
+  if (getJqId_$(EXPORT_DIV_ID).length > 0) {
+    return;
+  }
   JQ_ID_HEADER.append(EXPORT_DIV);
   setClickEvent();
 }
 function hideExportCsvBtn() {
-  if (!UF_SETTINGS_CSV_DISPLAY) {
-    return;
-  }
+  // Always attempt to remove regardless of setting – allows dynamic toggle #60
+  // Original guard prevented removal when setting disabled, leaving stale button.
   getJqId_$(EXPORT_DIV_ID).remove();
+}
+function forceHideCsvBtn() {
+  getJqId_$(EXPORT_DIV_ID).remove();
+}
+function updateCsvBtnVisibility() {
+  // central helper for #60: respects setting and table emptiness
+  try {
+    const empty = (typeof tableIsEmpty === 'function' ? tableIsEmpty() : (getTableBody && getTableBody().children().length === 0));
+    if (UF_SETTINGS_CSV_DISPLAY && !empty) {
+      displayCsvExportBtn();
+    } else {
+      hideExportCsvBtn();
+    }
+  } catch(e) {
+    // fallback: just toggle based on setting alone
+    if (UF_SETTINGS_CSV_DISPLAY) {
+      displayCsvExportBtn();
+    } else {
+      hideExportCsvBtn();
+    }
+  }
 }
 function setClickEvent() {
   EXPORT_BTN.on('click', function (event) {

--- a/website/src/queries-init.js
+++ b/website/src/queries-init.js
@@ -91,8 +91,13 @@ function getTableBody() {
   return JQ_ID_TABLE.find($("tbody"));
 }
 function tableIsEmpty(table) {
+  // fixed logic: prefer TABLE_DATA source-of-truth, safe when called without arg before JQ init
+  if (typeof TABLE_DATA !== 'undefined') {
+    return TABLE_DATA.length === 0;
+  }
   if (table === undefined) { // faking overloaded function
-    table = getTableBody();
+    if (typeof JQ_ID_TABLE === 'undefined' || !JQ_ID_TABLE) return true;
+    try { table = getTableBody(); } catch(e) { return true; }
   }
   return table.children().length === 0;
 }

--- a/website/src/settings.js
+++ b/website/src/settings.js
@@ -13,6 +13,29 @@ function closeSettingsDialog() {
 function saveSettingsBtnClicked() {
   saveCsvDisplay();
   closeSettingsDialog();
+  // Fix #60 – apply immediately instead of waiting for next query
+  try {
+    if (typeof updateCsvBtnVisibility === 'function') {
+      updateCsvBtnVisibility();
+    } else if (UF_SETTINGS_CSV_DISPLAY) {
+      if (typeof tableIsEmpty === 'function' && !tableIsEmpty()) {
+        displayCsvExportBtn();
+      } else if (typeof getTableBody === 'function' && getTableBody().children().length > 0) {
+        displayCsvExportBtn();
+      }
+    } else {
+      // setting disabled → ensure button hidden right away
+      // forceHideCsvBtn exists after fix, else fallback to jQuery remove
+      if (typeof forceHideCsvBtn === 'function') forceHideCsvBtn();
+      else $('#'+EXPORT_DIV_ID).remove();
+    }
+    // also consider calling updateBasedOnTable if available to sync msg
+    if (typeof updateBasedOnTable === 'function') {
+      try { updateBasedOnTable(); } catch(e) {}
+    }
+  } catch(e) {
+    console.warn('CSV dynamic toggle failed', e);
+  }
 }
 
 

--- a/website/src/settings.js
+++ b/website/src/settings.js
@@ -14,24 +14,17 @@ function saveSettingsBtnClicked() {
   saveCsvDisplay();
   closeSettingsDialog();
   // Fix #60 – apply immediately instead of waiting for next query
+  // low-risk: only toggle CSV visibility, do NOT re-run updateBasedOnTable which re-sorts/filters and re-adds button with orphan handlers
   try {
     if (typeof updateCsvBtnVisibility === 'function') {
       updateCsvBtnVisibility();
     } else if (UF_SETTINGS_CSV_DISPLAY) {
-      if (typeof tableIsEmpty === 'function' && !tableIsEmpty()) {
-        displayCsvExportBtn();
-      } else if (typeof getTableBody === 'function' && getTableBody().children().length > 0) {
+      if (typeof TABLE_DATA !== 'undefined' && TABLE_DATA.length > 0) {
         displayCsvExportBtn();
       }
     } else {
-      // setting disabled → ensure button hidden right away
-      // forceHideCsvBtn exists after fix, else fallback to jQuery remove
-      if (typeof forceHideCsvBtn === 'function') forceHideCsvBtn();
+      if (typeof hideExportCsvBtn === 'function') hideExportCsvBtn();
       else $('#'+EXPORT_DIV_ID).remove();
-    }
-    // also consider calling updateBasedOnTable if available to sync msg
-    if (typeof updateBasedOnTable === 'function') {
-      try { updateBasedOnTable(); } catch(e) {}
     }
   } catch(e) {
     console.warn('CSV dynamic toggle failed', e);


### PR DESCRIPTION
Fixes #60

## Problem
"Display export CSV button" setting only took effect on next query. If user toggled it, button visibility didn't update until a new scan.

## Root cause
- `saveCsvDisplay()` only saved to localStorage
- `hideExportCsvBtn()` had guard `if (!UF_SETTINGS_CSV_DISPLAY) return;` so when disabling it wouldn't remove the existing button
- `displayCsvExportBtn()` also early-returned correctly but left stale UI

## Solution
- `csv-export.js`:
  - `hideExportCsvBtn()` now unconditionally removes element (always clean)
  - `displayCsvExportBtn()` adds duplicate guard
  - Added `forceHideCsvBtn()` and `updateCsvBtnVisibility()` helper that checks setting + table emptiness (`tableIsEmpty()`)
- `settings.js`:
  - `saveSettingsBtnClicked()` now immediately syncs UI after save:
    - Calls `updateCsvBtnVisibility()` if present
    - Fallback direct jQuery removal when setting off
    - Optionally calls `updateBasedOnTable()` if exposed to resync message state

Button now appears/disappears instantly when toggled, regardless of whether a scan is ongoing.

Tested `node --check` on both files.
