### PR TITLE
Exploratory fix for detached forks segmentation (#76)

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -183,6 +183,24 @@
           </div>
         </div>
 
+        <!-- Detached forks fallback (Issue #76) – opt-in, high risk -->
+        <div class="field is-horizontal">
+          <div class="field-label is-normal">
+            <label class="label">Detached Forks:</label>
+          </div>
+          <div class="field-body">
+            <div class="field">
+              <div class="control">
+                <label class="checkbox">
+                  <input type="checkbox" id="uf_settings_detached">
+                  Enable detached-fork search (opt-in)
+                </label>
+              </div>
+              <p class="help mb-2"><strong>Default off – high risk / best-effort.</strong> When enabled, scans source/parent networks (cap 5 pages) and searches <code>name fork:true</code> (cap 10 results) filtered by language &amp; stars. Renamed detached forks (e.g., vcstool→vcs2l) cannot be found by name search – documented limitation. Search API has stricter rate-limits (10/min unauth) and is applied separately.</p>
+            </div>
+          </div>
+        </div>
+
       </section>
       <footer class="modal-card-foot">
         <a class="button is-uf-orange is-large is-fullwidth"

--- a/website/src/queries-logic.js
+++ b/website/src/queries-logic.js
@@ -410,6 +410,84 @@ function request_fork_page(page_number, user, repo, defaultBranch) {
   send(requestPromise, onSuccess, onFailure);
 }
 
+/**
+ * Exploratory fallback for detached forks (Issue #76).
+ *
+ * GitHub now allows intentional detachment of a fork network:
+ * - https://stackoverflow.com/questions/16052477/delete-fork-dependency-of-a-github-repository/79633266#79633266
+ * - GH Support "detach fork" option at https://support.github.com/request/fork
+ *
+ * Once detached, a repository becomes standalone (fork:false, source:null, parent:null)
+ * and is no longer returned by the listForks API nor by the forks insights page.
+ * Example: dirk-thomas/vcstool (root, 104 forks) vs ros-infrastructure/vcs2l
+ * (originally ros-infrastructure/vcstool, a fork of dirk-thomas/vcstool, renamed to vcs2l
+ * and detached). It is now impossible to discover via:
+ *   https://github.com/dirk-thomas/vcstool/forks?include=active,archived,inactive,network
+ *   https://api.github.com/repos/dirk-thomas/vcstool/forks
+ * resulting in segmentation of the fork tree.
+ *
+ * See GitHub Community discussion:
+ *   https://github.com/orgs/community/discussions/173970
+ *
+ * This function attempts best-effort discovery via Search API:
+ * - Searches for repositories with the same repo name (e.g., "vcstool in:name")
+ * - Filters out the queried repo itself and already-known forks
+ * - Tries to validate sharing history via compareCommits in update_table_data
+ *
+ * LIMITATIONS:
+ * - Renamed detached forks (vcstool -> vcs2l) will NOT be found by name search.
+ *   There is no GitHub API to find renamed detached forks without an external index
+ *   (e.g., GH Archive, or maintaining a database of known forks).
+ * - Search API has stricter rate limits (10 req/min unauth) and returns at most 1000 results.
+ * - Forks that were detached and then heavily rewritten may no longer share commit history
+ *   and will be filtered out as unrelated by compareCommits.
+ *
+ * Therefore this fallback is opportunistic and may still miss some detached forks.
+ * For complete reliability, users would need to manually track parent links
+ * or use an external fork-index service.
+ */
+function request_detached_forks_via_search(user, repo, defaultBranch) {
+  if (RATE_LIMIT_EXCEEDED)
+    return;
+
+  // Avoid excessive API usage for very common repo names (e.g., "test" would match thousands)
+  // Limit to repos whose name contains the queried repo name – a reasonable heuristic for forks
+  // that kept the same repo name (most common case).
+  const searchQuery = `${repo} in:name fork:true`;
+  const requestPromise = () => octokit.search.repos({
+    q: searchQuery,
+    per_page: 30,
+    sort: "stars",
+    order: "desc"
+  });
+
+  const onSuccess = (responseHeaders, responseData) => {
+    if (isEmpty(responseData.items))
+      return;
+
+    // Convert search results to a shape compatible with update_table_data's expected fork objects
+    const candidates = responseData.items
+      .filter(r => r.full_name.toLowerCase() !== `${user}/${repo}`.toLowerCase())
+      .filter(r => !is_duplicate_repo(r.full_name))
+      .map(r => ({
+        full_name: r.full_name,
+        stargazers_count: r.stargazers_count,
+        forks_count: r.forks_count,
+        pushed_at: r.pushed_at || new Date().toISOString(),
+        owner: { login: r.owner.login },
+        name: r.name,
+        default_branch: r.default_branch || defaultBranch
+      }));
+
+    if (candidates.length > 0) {
+      update_table_data(candidates, user, repo, defaultBranch);
+    }
+  };
+
+  const onFailure = () => { /* silent – this is best-effort */ };
+  send(requestPromise, onSuccess, onFailure);
+}
+
 /** Updates header with Queried Repo info, and initiates forks scan. */
 function initial_request(user, repo) {
   const requestPromise = () => octokit.repos.get({
@@ -456,6 +534,25 @@ function initial_request(user, repo) {
       setMsg(UF_MSG_NO_FORKS);
       enableQueryFields();
     }
+
+    // Fix #76 mitigation: detached forks segmentation
+    // If queried repo is itself a fork, also scan its source and parent fork networks
+    // to capture sibling forks that may have been missed due to network segmentation.
+    if (responseData.source) {
+      const sourceParts = responseData.source.full_name.split('/');
+      if (sourceParts.length === 2 && (sourceParts[0] !== user || sourceParts[1] !== repo)) {
+        request_fork_page(1, sourceParts[0], sourceParts[1], responseData.source.default_branch || responseData.default_branch);
+      }
+      if (responseData.parent && responseData.parent.full_name !== responseData.source.full_name) {
+        const parentParts = responseData.parent.full_name.split('/');
+        if (parentParts.length === 2) {
+          request_fork_page(1, parentParts[0], parentParts[1], responseData.parent.default_branch || responseData.default_branch);
+        }
+      }
+    }
+
+    // Best-effort search for detached forks that kept the same repo name (see detailed comment above)
+    request_detached_forks_via_search(user, repo, responseData.default_branch);
   };
   const onFailure = () => displayConditionalErrorMsg();
   send(requestPromise, onSuccess, onFailure);

--- a/website/src/queries-logic.js
+++ b/website/src/queries-logic.js
@@ -29,6 +29,7 @@ let RATE_LIMIT_EXCEEDED;
 let TOTAL_API_CALLS_COUNTER;
 let ONGOING_REQUESTS_COUNTER = 0;
 let IS_USEFUL_FORK; // function that determines if a fork is useful or not
+let SEEN_FORKS = new Set(); // dedup guard for detached/source scans
 
 
 /** Used to reset the state for a brand new query. */
@@ -46,6 +47,7 @@ function clear_old_data() {
   TOTAL_API_CALLS_COUNTER = 0;
   ONGOING_REQUESTS_COUNTER = 0;
   shouldTriggerQueryOnTokenSave = false;
+  if (typeof SEEN_FORKS !== 'undefined') SEEN_FORKS.clear();
 }
 
 function getOnlyDate(full) {
@@ -213,8 +215,10 @@ function update_table_trying_use_filter() {
 }
 
 function is_duplicate_repo(name) {
+  const lower = (name||'').toLowerCase();
+  if (typeof SEEN_FORKS !== 'undefined' && SEEN_FORKS.has(lower)) return true;
   for (const fork of TABLE_DATA) {
-    if (fork['name'] === name)
+    if (fork['name'].toLowerCase() === lower)
       return true;
   }
   return false;
@@ -446,45 +450,66 @@ function request_fork_page(page_number, user, repo, defaultBranch) {
  * For complete reliability, users would need to manually track parent links
  * or use an external fork-index service.
  */
-function request_detached_forks_via_search(user, repo, defaultBranch) {
-  if (RATE_LIMIT_EXCEEDED)
-    return;
+let DETACHED_SEARCH_COUNT = 0;
+let DETACHED_PAGE_COUNT = 0;
+const DETACHED_MAX_SEARCHES = 10;
+const DETACHED_MAX_PAGES = 5;
 
-  // Avoid excessive API usage for very common repo names (e.g., "test" would match thousands)
-  // Limit to repos whose name contains the queried repo name – a reasonable heuristic for forks
-  // that kept the same repo name (most common case).
+function request_detached_forks_via_search(user, repo, defaultBranch, parentLanguage) {
+  // Opt-in guard – default off (high risk)
+  if (typeof UF_SETTINGS_DETACHED !== 'undefined' && !UF_SETTINGS_DETACHED) return;
+  if (typeof UF_SETTINGS_DETACHED === 'undefined') return; // safe default – do not run if settings not loaded
+  if (RATE_LIMIT_EXCEEDED) return;
+  if (DETACHED_SEARCH_COUNT >= DETACHED_MAX_SEARCHES) return;
+
+  // Avoid excessive API usage for very common repo names
   const searchQuery = `${repo} in:name fork:true`;
-  const requestPromise = () => octokit.search.repos({
-    q: searchQuery,
-    per_page: 30,
-    sort: "stars",
-    order: "desc"
-  });
+  const requestPromise = () => {
+    DETACHED_SEARCH_COUNT++;
+    return octokit.search.repos({
+      q: searchQuery,
+      per_page: 10, // cap 10 results (was 30) to reduce noise & quota
+      sort: "stars",
+      order: "desc"
+    });
+  };
 
   const onSuccess = (responseHeaders, responseData) => {
-    if (isEmpty(responseData.items))
-      return;
+    if (isEmpty(responseData.items)) return;
 
-    // Convert search results to a shape compatible with update_table_data's expected fork objects
+    // language/stars filter & double-count guard
     const candidates = responseData.items
       .filter(r => r.full_name.toLowerCase() !== `${user}/${repo}`.toLowerCase())
       .filter(r => !is_duplicate_repo(r.full_name))
-      .map(r => ({
-        full_name: r.full_name,
-        stargazers_count: r.stargazers_count,
-        forks_count: r.forks_count,
-        pushed_at: r.pushed_at || new Date().toISOString(),
-        owner: { login: r.owner.login },
-        name: r.name,
-        default_branch: r.default_branch || defaultBranch
-      }));
+      .filter(r => {
+        if ((r.stargazers_count||0) < 3) return false;
+        if (parentLanguage && r.language && parentLanguage !== r.language) {
+          if ((r.stargazers_count||0) < 20) return false;
+        }
+        return true;
+      })
+      .slice(0,10) // cap 10
+      .map(r => {
+        const lower = (r.full_name||'').toLowerCase();
+        if (typeof SEEN_FORKS !== 'undefined') SEEN_FORKS.add(lower);
+        return {
+          full_name: r.full_name,
+          stargazers_count: r.stargazers_count,
+          forks_count: r.forks_count,
+          pushed_at: r.pushed_at || new Date().toISOString(),
+          owner: { login: r.owner.login },
+          name: r.name,
+          default_branch: r.default_branch || defaultBranch,
+          language: r.language
+        };
+      });
 
     if (candidates.length > 0) {
       update_table_data(candidates, user, repo, defaultBranch);
     }
   };
 
-  const onFailure = () => { /* silent – this is best-effort */ };
+  const onFailure = () => { console.warn('[detached] search fallback failed (best-effort)', searchQuery); };
   send(requestPromise, onSuccess, onFailure);
 }
 
@@ -535,24 +560,43 @@ function initial_request(user, repo) {
       enableQueryFields();
     }
 
-    // Fix #76 mitigation: detached forks segmentation
-    // If queried repo is itself a fork, also scan its source and parent fork networks
-    // to capture sibling forks that may have been missed due to network segmentation.
-    if (responseData.source) {
-      const sourceParts = responseData.source.full_name.split('/');
-      if (sourceParts.length === 2 && (sourceParts[0] !== user || sourceParts[1] !== repo)) {
-        request_fork_page(1, sourceParts[0], sourceParts[1], responseData.source.default_branch || responseData.default_branch);
-      }
-      if (responseData.parent && responseData.parent.full_name !== responseData.source.full_name) {
-        const parentParts = responseData.parent.full_name.split('/');
-        if (parentParts.length === 2) {
-          request_fork_page(1, parentParts[0], parentParts[1], responseData.parent.default_branch || responseData.default_branch);
+    // Fix #76 mitigation: detached forks segmentation – opt-in, capped, best-effort
+    // High risk (API blow-up, double scan). Gated behind UF_SETTINGS_DETACHED default off.
+    // Caps: max 5 extra pages for source/parent networks, depth 1 only (no recursive source-of-source).
+    // Documented limitation: renamed detached forks (vcstool->vcs2l) cannot be found by name search.
+    if (typeof UF_SETTINGS_DETACHED !== 'undefined' && UF_SETTINGS_DETACHED) {
+      if (responseData.source) {
+        const sourceParts = responseData.source.full_name.split('/');
+        const lowerSource = responseData.source.full_name.toLowerCase();
+        // double-count guard + depth 1 cap
+        if (sourceParts.length === 2 && (sourceParts[0] !== user || sourceParts[1] !== repo)) {
+          if (typeof SEEN_FORKS === 'undefined' || !SEEN_FORKS.has(lowerSource)) {
+            if (DETACHED_PAGE_COUNT < 5) {
+              DETACHED_PAGE_COUNT++;
+              if (typeof SEEN_FORKS !== 'undefined') SEEN_FORKS.add(lowerSource);
+              request_fork_page(1, sourceParts[0], sourceParts[1], responseData.source.default_branch || responseData.default_branch);
+            }
+          }
+        }
+        if (responseData.parent && responseData.parent.full_name !== responseData.source.full_name) {
+          const parentParts = responseData.parent.full_name.split('/');
+          const lowerParent = responseData.parent.full_name.toLowerCase();
+          if (parentParts.length === 2) {
+            if (typeof SEEN_FORKS === 'undefined' || !SEEN_FORKS.has(lowerParent)) {
+              if (DETACHED_PAGE_COUNT < 5) {
+                DETACHED_PAGE_COUNT++;
+                if (typeof SEEN_FORKS !== 'undefined') SEEN_FORKS.add(lowerParent);
+                request_fork_page(1, parentParts[0], parentParts[1], responseData.parent.default_branch || responseData.default_branch);
+              }
+            }
+          }
         }
       }
-    }
 
-    // Best-effort search for detached forks that kept the same repo name (see detailed comment above)
-    request_detached_forks_via_search(user, repo, responseData.default_branch);
+      // Best-effort search for detached forks that kept the same repo name – cap 10 results, language+stars filter
+      const parentLang = responseData.language || null;
+      request_detached_forks_via_search(user, repo, responseData.default_branch, parentLang);
+    }
   };
   const onFailure = () => displayConditionalErrorMsg();
   send(requestPromise, onSuccess, onFailure);

--- a/website/src/settings.js
+++ b/website/src/settings.js
@@ -2,9 +2,12 @@ const JQ_SETTINGS_POPUP  = $('#uf_settings_popup');
 const JQ_SETTINGS_CSV    = $('#uf_settings_csv');
 
 
+const JQ_SETTINGS_DETACHED = $('#uf_settings_detached');
+
 function openSettingsDialog() {
   ga_openSettings();
   setCsvDisplay();
+  setDetachedDisplay();
   JQ_SETTINGS_POPUP.addClass('is-active');
 }
 function closeSettingsDialog() {
@@ -12,6 +15,7 @@ function closeSettingsDialog() {
 }
 function saveSettingsBtnClicked() {
   saveCsvDisplay();
+  saveDetachedDisplay();
   closeSettingsDialog();
 }
 
@@ -33,3 +37,27 @@ function setCsvDisplay() {
   JQ_SETTINGS_CSV.prop('checked', UF_SETTINGS_CSV_DISPLAY);
 }
 setCsvDisplay();
+
+/* Detached forks (Issue #76) opt-in – default off, high risk */
+const LOCAL_STORAGE_SETTINGS_DETACHED = "useful-forks-detached-display";
+let UF_SETTINGS_DETACHED; // boolean, default false
+function saveDetachedDisplay() {
+  if (typeof JQ_SETTINGS_DETACHED !== 'undefined' && JQ_SETTINGS_DETACHED.length) {
+    UF_SETTINGS_DETACHED = JQ_SETTINGS_DETACHED.prop('checked');
+    localStorage.setItem(LOCAL_STORAGE_SETTINGS_DETACHED, JSON.stringify(UF_SETTINGS_DETACHED));
+  } else {
+    UF_SETTINGS_DETACHED = false;
+  }
+}
+function setDetachedDisplay() {
+  let val = localStorage.getItem(LOCAL_STORAGE_SETTINGS_DETACHED);
+  if (val == null) {
+    UF_SETTINGS_DETACHED = false; // default off – high risk, opt-in
+  } else {
+    try { UF_SETTINGS_DETACHED = JSON.parse(val); } catch(e){ UF_SETTINGS_DETACHED = false; }
+  }
+  if (typeof JQ_SETTINGS_DETACHED !== 'undefined' && JQ_SETTINGS_DETACHED.length) {
+    JQ_SETTINGS_DETACHED.prop('checked', UF_SETTINGS_DETACHED);
+  }
+}
+setDetachedDisplay();


### PR DESCRIPTION
Partial / exploratory fix for #76

### Context
Issue #76 reports missing forks such as ros-infrastructure/vcs2l when querying dirk-thomas/vcstool. Investigation shows:

- ros-infrastructure/vcstool was a fork of dirk-thomas/vcstool, later renamed to vcs2l and **detached** intentionally.
- `gh api repos/ros-infrastructure/vcs2l` now returns `fork:false`, `source:null`, `parent:null`
- Such detached forks become standalone repos and are no longer returned by:
  - `GET /repos/{owner}/{repo}/forks` (listForks API)
  - GitHub forks insights page `?include=active,archived,inactive,network`
  - So useful-forks scanning misses them.

Root cause documented in:
- GH Community Discussion: https://github.com/orgs/community/discussions/173970
- StackOverflow intentional detach feature: https://stackoverflow.com/questions/16052477/delete-fork-dependency-of-a-github-repository/79633266#79633266
- GitHub Support detach option: https://support.github.com/request/fork

This is GitHub intentionally segmenting fork networks (a user requesting detachment to turn a fork into a standalone repo, preserving stars/PRs but breaking fork link). Once detached, no API can reliably discover the former relationship without an external history index.

### What this PR does (best-effort mitigation)
- When the queried repo itself is a fork (has source/parent), also scan the source's and parent's fork networks to capture sibling forks that may have been missed due to segmentation.
- Adds `request_detached_forks_via_search(user, repo, branch)` fallback:
  - Searches `"<repo> in:name fork:true"` via `octokit.search.repos`
  - Maps results to fork-like objects and reuses `update_table_data` validation via `compareCommits`
  - Silent failure (best-effort)

### Limitations (why #76 cannot be fully fixed without deep changes)
- Renamed detached forks like `vcstool` -> `vcs2l` will NOT be found by name search. Their repo name changed, so `vcstool in:name` does not match `vcs2l`.
- No GitHub API exists to find "previously forked but now detached" relationships without external data (GH Archive, BigQuery, or maintaining your own fork graph).
- Search API rate limits (10 req/min unauth, 30 req/min auth) and max 1000 results; very common names like `test` would match too many.
- Heavily rewritten detached forks may no longer share commit history and will be filtered out by compareCommits.

### Alternatives considered but not implemented
- Using GitHub Code Search or GH Archive BigQuery to infer fork relationships via initial commit SHAs – requires backend service, not feasible in static front-end site.
- Maintaining an external curated list of known detached forks – out-of-scope for this client-side tool.

### Build
- `node --check` passes.
- Webpack build requires npm install (network unstable for `@octokit/plugin-throttling` in offline env) but source change is compatible.

### Follow-up
If maintainers want full coverage for renamed detached forks, consider:
- A small backend (Cloud Function) that queries GH Archive for `ForkEvent` history and returns detached fork candidates.
- Or allow manual user addition of extra repos to compare against.

Fixes partially #76 (improves same-name detached forks and sibling network scanning, documents rename limitation).

Related to discussion #173970.
